### PR TITLE
log: add context logger helpers and WithFields; add tests and example

### DIFF
--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/rs/zerolog"
+	logger "github.com/totvs/go-sdk/log"
+)
+
+func main() {
+	// basic logger
+	l := logger.New(os.Stdout, zerolog.InfoLevel)
+	ctx := logger.ContextWithTrace(context.Background(), "trace-1234")
+	l = logger.WithTraceFromContext(ctx, l)
+	l.Info().Msg("application started")
+
+	// inject logger into context for library code
+	lg := logger.New(os.Stdout, zerolog.DebugLevel)
+	ctx2 := logger.ContextWithLogger(context.Background(), lg)
+	lg2 := logger.FromContext(ctx2)
+	lg2.Info().Msg("using injected logger")
+
+	// add fields
+	lg3 := logger.WithFields(lg2, map[string]interface{}{"service": "orders", "version": 3})
+	lg3.Info().Msg("request processed")
+
+	// HTTP server with middleware
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	// listen on :8080 (ctrl-c to stop)
+	http.ListenAndServe(":8080", logger.HTTPMiddleware(mux))
+}

--- a/log/README.md
+++ b/log/README.md
@@ -31,6 +31,22 @@ func main() {
 }
 ```
 
+Injecting logger into context:
+
+```go
+// create a logger and store it in the context so library code can use it
+lg := logger.New(os.Stdout, zerolog.DebugLevel)
+ctx := logger.ContextWithLogger(context.Background(), lg)
+
+// later, library code can get the logger or fall back to default
+lg2 := logger.FromContext(ctx)
+lg2.Info().Msg("using injected logger")
+
+// adding multiple fields conveniently
+lg3 := logger.WithFields(lg2, map[string]interface{}{"service": "orders", "version": 3})
+lg3.Info().Msg("request processed")
+```
+
 <!-- exemplo executável removido -->
 
 Dicas:

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,76 +1,129 @@
 package logger
 
 import (
-    "context"
-    "io"
-    "net/http"
-    "os"
-    "time"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"time"
 
-    "github.com/rs/zerolog"
+	"github.com/rs/zerolog"
 )
 
 type ctxKey string
 
 const traceIDKey ctxKey = "trace-id"
+const loggerKey ctxKey = "logger"
 
 // New creates a zerolog logger that writes JSON to the provided writer and uses the given level.
 func New(w io.Writer, level zerolog.Level) zerolog.Logger {
-    zerolog.TimeFieldFormat = time.RFC3339
-    logger := zerolog.New(w).With().Timestamp().Logger().Level(level)
-    return logger
+	zerolog.TimeFieldFormat = time.RFC3339
+	logger := zerolog.New(w).With().Timestamp().Logger().Level(level)
+	return logger
 }
 
 // NewDefault returns a JSON logger writing to stdout with level taken from LOG_LEVEL or Info.
 func NewDefault() zerolog.Logger {
-    lvl := zerolog.InfoLevel
-    if s := os.Getenv("LOG_LEVEL"); s != "" {
-        if l, err := zerolog.ParseLevel(s); err == nil {
-            lvl = l
-        }
-    }
-    return New(os.Stdout, lvl)
+	lvl := zerolog.InfoLevel
+	if s := os.Getenv("LOG_LEVEL"); s != "" {
+		if l, err := zerolog.ParseLevel(s); err == nil {
+			lvl = l
+		}
+	}
+	return New(os.Stdout, lvl)
 }
 
 // ContextWithTrace returns a new context containing the provided trace id.
 func ContextWithTrace(ctx context.Context, traceID string) context.Context {
-    return context.WithValue(ctx, traceIDKey, traceID)
+	return context.WithValue(ctx, traceIDKey, traceID)
 }
 
 // TraceIDFromContext extracts the trace id from the context, if present.
 func TraceIDFromContext(ctx context.Context) string {
-    if ctx == nil {
-        return ""
-    }
-    if v := ctx.Value(traceIDKey); v != nil {
-        if s, ok := v.(string); ok {
-            return s
-        }
-    }
-    return ""
+	if ctx == nil {
+		return ""
+	}
+	if v := ctx.Value(traceIDKey); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // WithTraceFromContext returns a logger that includes the `trace_id` field when a trace id exists in the context.
 func WithTraceFromContext(ctx context.Context, l zerolog.Logger) zerolog.Logger {
-    if tid := TraceIDFromContext(ctx); tid != "" {
-        return l.With().Str("trace_id", tid).Logger()
-    }
-    return l
+	if tid := TraceIDFromContext(ctx); tid != "" {
+		return l.With().Str("trace_id", tid).Logger()
+	}
+	return l
+}
+
+// ContextWithLogger stores a zerolog.Logger in the context so callers can
+// inject a logger that will be used by library code.
+func ContextWithLogger(ctx context.Context, l zerolog.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, l)
+}
+
+// LoggerFromContext extracts a zerolog.Logger from the context. The boolean
+// indicates whether a logger was present.
+func LoggerFromContext(ctx context.Context) (zerolog.Logger, bool) {
+	if ctx == nil {
+		return zerolog.Logger{}, false
+	}
+	if v := ctx.Value(loggerKey); v != nil {
+		if lg, ok := v.(zerolog.Logger); ok {
+			return lg, true
+		}
+	}
+	return zerolog.Logger{}, false
+}
+
+// FromContext returns the logger stored in the context or a sensible default
+// created by NewDefault when none is present.
+func FromContext(ctx context.Context) zerolog.Logger {
+	if l, ok := LoggerFromContext(ctx); ok {
+		return l
+	}
+	return NewDefault()
+}
+
+// WithFields returns a logger augmented with the provided fields. It accepts
+// a map of string->interface{} and will use type-specific setters when
+// possible, falling back to `Interface` for unknown types.
+func WithFields(l zerolog.Logger, fields map[string]interface{}) zerolog.Logger {
+	c := l.With()
+	for k, v := range fields {
+		switch val := v.(type) {
+		case string:
+			c = c.Str(k, val)
+		case int:
+			c = c.Int(k, val)
+		case int64:
+			c = c.Int64(k, val)
+		case bool:
+			c = c.Bool(k, val)
+		case float64:
+			c = c.Float64(k, val)
+		default:
+			c = c.Interface(k, val)
+		}
+	}
+	return c.Logger()
 }
 
 // HTTPMiddleware adds trace id from headers into the request context and logs incoming requests with trace_id.
 // It looks for `X-Request-Id` or `X-Correlation-Id` headers.
 func HTTPMiddleware(next http.Handler) http.Handler {
-    base := NewDefault()
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        trace := r.Header.Get("X-Request-Id")
-        if trace == "" {
-            trace = r.Header.Get("X-Correlation-Id")
-        }
-        ctx := ContextWithTrace(r.Context(), trace)
-        l := WithTraceFromContext(ctx, base).With().Str("method", r.Method).Str("path", r.URL.Path).Logger()
-        l.Info().Msg("http request received")
-        next.ServeHTTP(w, r.WithContext(ctx))
-    })
+	base := NewDefault()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trace := r.Header.Get("X-Request-Id")
+		if trace == "" {
+			trace = r.Header.Get("X-Correlation-Id")
+		}
+		ctx := ContextWithTrace(r.Context(), trace)
+		l := WithTraceFromContext(ctx, base).With().Str("method", r.Method).Str("path", r.URL.Path).Logger()
+		l.Info().Msg("http request received")
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
-

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,111 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestWithFields(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := New(buf, zerolog.DebugLevel)
+
+	fields := map[string]interface{}{
+		"str": "s",
+		"i":   42,
+		"i64": int64(99),
+		"b":   true,
+		"f":   3.14,
+		"obj": map[string]interface{}{"a": "b"},
+	}
+
+	lg := WithFields(l, fields)
+	lg.Info().Msg("testfields")
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("no log output")
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("invalid json: %v, raw: %s", err, out)
+	}
+
+	if m["str"] != "s" {
+		t.Fatalf("unexpected str: %v", m["str"])
+	}
+	// JSON numbers are decoded as float64
+	if m["i"].(float64) != 42 {
+		t.Fatalf("unexpected i: %v", m["i"])
+	}
+	if m["b"] != true {
+		t.Fatalf("unexpected b: %v", m["b"])
+	}
+	if _, ok := m["obj"].(map[string]interface{}); !ok {
+		t.Fatalf("expected obj to be object, got: %T", m["obj"])
+	}
+}
+
+func TestContextLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := New(buf, zerolog.DebugLevel)
+
+	ctx := ContextWithLogger(context.Background(), l)
+	if _, ok := LoggerFromContext(ctx); !ok {
+		t.Fatal("expected logger in context")
+	}
+
+	lg := FromContext(ctx)
+	lg.Info().Msg("ctxmsg")
+
+	if !strings.Contains(buf.String(), "ctxmsg") {
+		t.Fatalf("expected ctxmsg in output, got: %s", buf.String())
+	}
+
+	// nil context should not panic and should return false
+	if _, ok := LoggerFromContext(nil); ok {
+		t.Fatal("expected no logger from nil context")
+	}
+}
+
+func TestHTTPMiddlewareLogsTrace(t *testing.T) {
+	// capture stdout because HTTPMiddleware uses NewDefault() which writes to stdout
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe error: %v", err)
+	}
+	os.Stdout = w
+
+	// perform a request with trace header
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Request-Id", "trace-1")
+	resp := httptest.NewRecorder()
+	// use the handler directly to ensure middleware executes in-process
+	handler := HTTPMiddleware(http.HandlerFunc(func(wr http.ResponseWriter, r *http.Request) {
+		wr.Write([]byte("ok"))
+	}))
+	handler.ServeHTTP(resp, req)
+
+	// restore stdout and read buffer
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	s := string(out)
+
+	if !strings.Contains(s, "http request received") {
+		t.Fatalf("expected http log, got: %s", s)
+	}
+	if !strings.Contains(s, "trace-1") {
+		t.Fatalf("expected trace id in log, got: %s", s)
+	}
+}


### PR DESCRIPTION
Resumo
- Adiciona helpers para injeção/extração de `zerolog.Logger` via `context`.
- Adiciona `WithFields` para anexar múltiplos campos facilmente.
- Adiciona testes (`log/logger_test.go`) cobrindo helpers e middleware.
- Adiciona exemplo executável (`examples/logger/main.go`).
- Atualiza `log/README.md` com exemplos de uso.

Motivação
- Permitir que consumidores injetem seu próprio logger no contexto.
- Facilitar adição de campos estruturados ao logger.

Como testar
- `go test ./log -v`
- `go run ./examples/logger` (inicia servidor em `:8080`)

Notas
- Mantém `zerolog` como backend (sem breaking changes).