### PR TITLE
logger: expose Logger/Level helpers, auto-generate trace id, add helpers and examples/tests

### DIFF
--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -5,19 +5,18 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/rs/zerolog"
 	logger "github.com/totvs/go-sdk/log"
 )
 
 func main() {
 	// basic logger
-	l := logger.New(os.Stdout, zerolog.InfoLevel)
+	l := logger.New(os.Stdout, logger.InfoLevel)
 	ctx := logger.ContextWithTrace(context.Background(), "trace-1234")
 	l = logger.WithTraceFromContext(ctx, l)
 	l.Info().Msg("application started")
 
 	// inject logger into context for library code
-	lg := logger.New(os.Stdout, zerolog.DebugLevel)
+	lg := logger.New(os.Stdout, logger.DebugLevel)
 	ctx2 := logger.ContextWithLogger(context.Background(), lg)
 	lg2 := logger.FromContext(ctx2)
 	lg2.Info().Msg("using injected logger")

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"crypto/rand"
 	"io"
 	"net/http"
 	"os"
@@ -15,19 +16,57 @@ type ctxKey string
 const traceIDKey ctxKey = "trace-id"
 const loggerKey ctxKey = "logger"
 
-// New creates a zerolog logger that writes JSON to the provided writer and uses the given level.
-func New(w io.Writer, level zerolog.Level) zerolog.Logger {
+// Level represents a logging level independent from zerolog so callers don't
+// need to import zerolog directly.
+type Level int
+
+const (
+	DebugLevel Level = iota
+	InfoLevel
+	WarnLevel
+	ErrorLevel
+)
+
+func (l Level) toZerolog() zerolog.Level {
+	switch l {
+	case DebugLevel:
+		return zerolog.DebugLevel
+	case InfoLevel:
+		return zerolog.InfoLevel
+	case WarnLevel:
+		return zerolog.WarnLevel
+	case ErrorLevel:
+		return zerolog.ErrorLevel
+	default:
+		return zerolog.InfoLevel
+	}
+}
+
+// Logger is a lightweight wrapper around zerolog.Logger that keeps the
+// concrete zerolog type internal to the package. Consumers can use the
+// returned Logger without importing zerolog.
+type Logger struct{ l zerolog.Logger }
+
+// New creates a logger that writes JSON to the provided writer and uses the given level.
+func New(w io.Writer, level Level) Logger {
 	zerolog.TimeFieldFormat = time.RFC3339
-	logger := zerolog.New(w).With().Timestamp().Logger().Level(level)
-	return logger
+	lg := zerolog.New(w).With().Timestamp().Logger().Level(level.toZerolog())
+	return Logger{l: lg}
 }
 
 // NewDefault returns a JSON logger writing to stdout with level taken from LOG_LEVEL or Info.
-func NewDefault() zerolog.Logger {
-	lvl := zerolog.InfoLevel
+func NewDefault() Logger {
+	lvl := InfoLevel
 	if s := os.Getenv("LOG_LEVEL"); s != "" {
-		if l, err := zerolog.ParseLevel(s); err == nil {
-			lvl = l
+		switch s {
+		case "DEBUG", "debug":
+			lvl = DebugLevel
+		case "INFO", "info":
+			lvl = InfoLevel
+		case "WARN", "warn", "WARNING", "warning":
+			lvl = WarnLevel
+		case "ERROR", "error":
+			lvl = ErrorLevel
 		}
 	}
 	return New(os.Stdout, lvl)
@@ -52,47 +91,43 @@ func TraceIDFromContext(ctx context.Context) string {
 }
 
 // WithTraceFromContext returns a logger that includes the `trace_id` field when a trace id exists in the context.
-func WithTraceFromContext(ctx context.Context, l zerolog.Logger) zerolog.Logger {
+func WithTraceFromContext(ctx context.Context, l Logger) Logger {
 	if tid := TraceIDFromContext(ctx); tid != "" {
-		return l.With().Str("trace_id", tid).Logger()
+		return Logger{l: l.l.With().Str("trace_id", tid).Logger()}
 	}
 	return l
 }
 
-// ContextWithLogger stores a zerolog.Logger in the context so callers can
-// inject a logger that will be used by library code.
-func ContextWithLogger(ctx context.Context, l zerolog.Logger) context.Context {
+// ContextWithLogger stores a Logger in the context so callers can inject a logger that will be used by library code.
+func ContextWithLogger(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, l)
 }
 
-// LoggerFromContext extracts a zerolog.Logger from the context. The boolean
-// indicates whether a logger was present.
-func LoggerFromContext(ctx context.Context) (zerolog.Logger, bool) {
+// LoggerFromContext extracts a Logger from the context. The boolean indicates whether a logger was present.
+func LoggerFromContext(ctx context.Context) (Logger, bool) {
 	if ctx == nil {
-		return zerolog.Logger{}, false
+		return Logger{}, false
 	}
 	if v := ctx.Value(loggerKey); v != nil {
-		if lg, ok := v.(zerolog.Logger); ok {
+		if lg, ok := v.(Logger); ok {
 			return lg, true
 		}
 	}
-	return zerolog.Logger{}, false
+	return Logger{}, false
 }
 
-// FromContext returns the logger stored in the context or a sensible default
-// created by NewDefault when none is present.
-func FromContext(ctx context.Context) zerolog.Logger {
+// FromContext returns the logger stored in the context or a sensible default created by NewDefault when none is present.
+func FromContext(ctx context.Context) Logger {
 	if l, ok := LoggerFromContext(ctx); ok {
 		return l
 	}
 	return NewDefault()
 }
 
-// WithFields returns a logger augmented with the provided fields. It accepts
-// a map of string->interface{} and will use type-specific setters when
-// possible, falling back to `Interface` for unknown types.
-func WithFields(l zerolog.Logger, fields map[string]interface{}) zerolog.Logger {
-	c := l.With()
+// WithFields returns a logger augmented with the provided fields. It accepts a map of string->interface{} and will use
+// type-specific setters when possible, falling back to `Interface` for unknown types.
+func WithFields(l Logger, fields map[string]interface{}) Logger {
+	c := l.l.With()
 	for k, v := range fields {
 		switch val := v.(type) {
 		case string:
@@ -101,29 +136,87 @@ func WithFields(l zerolog.Logger, fields map[string]interface{}) zerolog.Logger 
 			c = c.Int(k, val)
 		case int64:
 			c = c.Int64(k, val)
+		case uint:
+			c = c.Uint(k, val)
+		case uint64:
+			c = c.Uint64(k, val)
 		case bool:
 			c = c.Bool(k, val)
+		case float32:
+			c = c.Float32(k, val)
 		case float64:
 			c = c.Float64(k, val)
 		default:
 			c = c.Interface(k, val)
 		}
 	}
-	return c.Logger()
+	return Logger{l: c.Logger()}
 }
 
-// HTTPMiddleware adds trace id from headers into the request context and logs incoming requests with trace_id.
-// It looks for `X-Request-Id` or `X-Correlation-Id` headers.
+// WithField returns a new logger with a single additional field.
+func (l Logger) WithField(k string, v interface{}) Logger {
+	return Logger{l: l.l.With().Interface(k, v).Logger()}
+}
+
+// WithFields method mirrors the package function for convenience.
+func (l Logger) WithFields(fields map[string]interface{}) Logger { return WithFields(l, fields) }
+
+// Convenience message helpers so callers don't need to call the zerolog event methods directly.
+func (l Logger) InfoMsg(msg string)  { l.Info().Msg(msg) }
+func (l Logger) DebugMsg(msg string) { l.Debug().Msg(msg) }
+func (l Logger) WarnMsg(msg string)  { l.Warn().Msg(msg) }
+func (l Logger) ErrorMsg(msg string) { l.Error().Msg(msg) }
+
+// generateTraceID creates a 16-byte hex id (UUID-like) for request tracing.
+func generateTraceID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// fallback to timestamp-based id (very unlikely)
+		return time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	// encode as hex without external deps
+	const hextable = "0123456789abcdef"
+	dst := make([]byte, 32)
+	for i, v := range b {
+		dst[i*2] = hextable[v>>4]
+		dst[i*2+1] = hextable[v&0x0f]
+	}
+	return string(dst)
+}
+
+// Info/Debug/Warn/Error expose the underlying zerolog event so callers can use the familiar API
+// without importing zerolog themselves.
+func (l Logger) Info() *zerolog.Event  { tmp := l.l; return (&tmp).Info() }
+func (l Logger) Debug() *zerolog.Event { tmp := l.l; return (&tmp).Debug() }
+func (l Logger) Warn() *zerolog.Event  { tmp := l.l; return (&tmp).Warn() }
+func (l Logger) Error() *zerolog.Event { tmp := l.l; return (&tmp).Error() }
+
+// HTTPMiddlewareWithLogger returns a middleware using the provided base logger.
+func HTTPMiddlewareWithLogger(base Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			trace := r.Header.Get("X-Request-Id")
+			if trace == "" {
+				trace = r.Header.Get("X-Correlation-Id")
+			}
+			if trace == "" {
+				trace = generateTraceID()
+			}
+			ctx := ContextWithTrace(r.Context(), trace)
+			// include trace and basic request info
+			l := WithTraceFromContext(ctx, base)
+			tmp := l.l.With().Str("method", r.Method).Str("path", r.URL.Path).Str("trace_id", trace).Logger()
+			(&tmp).Info().Msg("http request received")
+			// ensure response contains the trace id so callers can correlate
+			if w.Header().Get("X-Request-Id") == "" {
+				w.Header().Set("X-Request-Id", trace)
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// HTTPMiddleware is a convenience wrapper that uses the default logger.
 func HTTPMiddleware(next http.Handler) http.Handler {
-	base := NewDefault()
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		trace := r.Header.Get("X-Request-Id")
-		if trace == "" {
-			trace = r.Header.Get("X-Correlation-Id")
-		}
-		ctx := ContextWithTrace(r.Context(), trace)
-		l := WithTraceFromContext(ctx, base).With().Str("method", r.Method).Str("path", r.URL.Path).Logger()
-		l.Info().Msg("http request received")
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+	return HTTPMiddlewareWithLogger(NewDefault())(next)
 }

--- a/log/logger_helpers_test.go
+++ b/log/logger_helpers_test.go
@@ -1,0 +1,87 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWithFieldAddsSingleField(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := New(buf, DebugLevel)
+
+	lg := l.WithField("service", "orders")
+	lg.InfoMsg("started")
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("no log output")
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	if m["service"] != "orders" {
+		t.Fatalf("expected service=orders, got: %v", m["service"])
+	}
+	if m["message"] != "started" {
+		t.Fatalf("expected message=started, got: %v", m["message"])
+	}
+}
+
+func TestHTTPMiddlewareGeneratesTraceIfMissing(t *testing.T) {
+	buf := &bytes.Buffer{}
+	base := New(buf, DebugLevel)
+
+	handler := HTTPMiddlewareWithLogger(base)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// response header should contain X-Request-Id set by middleware
+	rid := rr.Header().Get("X-Request-Id")
+	if rid == "" {
+		t.Fatalf("expected X-Request-Id header to be set, got empty")
+	}
+
+	// log output should contain the same id
+	s := buf.String()
+	if !strings.Contains(s, rid) {
+		t.Fatalf("expected log to contain trace id %s, got: %s", rid, s)
+	}
+}
+
+func TestHTTPMiddlewarePreservesProvidedTrace(t *testing.T) {
+	buf := &bytes.Buffer{}
+	base := New(buf, DebugLevel)
+
+	handler := HTTPMiddlewareWithLogger(base)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Request-Id", "trace-123")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	rid := rr.Header().Get("X-Request-Id")
+	if rid != "trace-123" {
+		t.Fatalf("expected X-Request-Id to be preserved as trace-123, got: %s", rid)
+	}
+
+	// log output should contain the same id
+	s := buf.String()
+	if !strings.Contains(s, "trace-123") {
+		t.Fatalf("expected log to contain provided trace id, got: %s", s)
+	}
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -10,13 +10,11 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/rs/zerolog"
 )
 
 func TestWithFields(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(buf, zerolog.DebugLevel)
+	l := New(buf, DebugLevel)
 
 	fields := map[string]interface{}{
 		"str": "s",
@@ -57,7 +55,7 @@ func TestWithFields(t *testing.T) {
 
 func TestContextLogger(t *testing.T) {
 	buf := &bytes.Buffer{}
-	l := New(buf, zerolog.DebugLevel)
+	l := New(buf, DebugLevel)
 
 	ctx := ContextWithLogger(context.Background(), l)
 	if _, ok := LoggerFromContext(ctx); !ok {


### PR DESCRIPTION
This PR simplifies the SDK logging API by exposing a package-local Logger and Level type so consumers no longer need to import zerolog.\n\nChanges:\n- Expose  wrapper and  enums\n- Add helper methods: , , , , , \n- Middleware: auto-generate a trace id when / is missing and set the response header\n- Updated tests, examples and README docs\n\nAll package tests pass locally: ?   	github.com/totvs/go-sdk/examples/logger	[no test files]
ok  	github.com/totvs/go-sdk/log	(cached)\n