### PR TITLE
fix: Headers must be set BEFORE WriteHeader.

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -20,8 +20,8 @@ func HTTPAuthorizationBearerTokenMiddleware(authorizationBearerToken *authorizat
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			claims, err := authorizationBearerToken.IsValidBearerToken(r)
 			if err != nil {
-				w.WriteHeader(http.StatusUnauthorized)
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusUnauthorized)
 				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
 				return
 			}


### PR DESCRIPTION
## The code is setting the HTTP header in the wrong order:

- w.WriteHeader(http.StatusUnauthorized)                // 1st - Sends response
- w.Header().Set("Content-Type", "application/json") // 2nd - Too late!

Why is this a problem?

> When you call WriteHeader(), Go sends the HTTP response to the client immediately. After that, you can no longer change the headers - they are ignored.