### PR TITLE
feat(kubernetes/status): add status module with KStatus integration

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.25.5
-lefthook 2.0.9
+golang   1.26.2
+lefthook 2.0.15

--- a/Makefile
+++ b/Makefile
@@ -1,99 +1,68 @@
-## Makefile para facilitar tarefas comuns do projeto go-sdk
+SHELL := /bin/bash
 
-.PHONY: test test-v test-race cover cover-html fmt vet build tidy ci setup
+HACK_DIR := hack/automations
 
-TESTPKGS := ./...
-TESTFLAGS ?=
+.PHONY: all help fmt vet build tidy ci test test-v test-race cover cover-html setup \
+        security-% setup example-%
 
-include examples.mk
+all: build
 
-.PHONY: run-example
+##@ General
 
-# default log level for the example (can be overridden: `make run-example LOG_LEVEL=info`)
-LOG_LEVEL ?= DEBUG
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Executa todos os testes
-test:
-	go test $(TESTFLAGS) $(TESTPKGS)
+##@ Development
 
-# Executa os testes em modo verbose
-test-v:
-	go test -v $(TESTPKGS)
+fmt: ## Run gofmt
+	@$(MAKE) -f $(HACK_DIR)/build.mk fmt
 
-# Testes com detector de race e cobertura mínima
-test-race:
-	go test -race -cover -covermode=atomic $(TESTPKGS)
+vet: ## Run go vet
+	@$(MAKE) -f $(HACK_DIR)/build.mk vet
 
-## Gera arquivo de cobertura e mostra resumo
-cover:
-	go test -coverprofile=coverage.out $(TESTPKGS)
-	go tool cover -func=coverage.out
+build: ## Build all packages
+	@$(MAKE) -f $(HACK_DIR)/build.mk build
 
-## Gera relatório HTML de cobertura
-cover-html:
-	go test -coverprofile=coverage.out $(TESTPKGS)
-	go tool cover -html=coverage.out
+tidy: ## Run go mod tidy
+	@$(MAKE) -f $(HACK_DIR)/build.mk tidy
 
-## Formata o código (gofmt)
-fmt:
-	gofmt -w .
+ci: ## Run fmt + vet + test (CI pipeline)
+	@$(MAKE) -f $(HACK_DIR)/build.mk ci
 
-## Executa go vet
-vet:
-	go vet $(TESTPKGS)
+##@ Test
 
-## Compila os pacotes
-build:
-	go build $(TESTPKGS)
+test: ## Run all tests
+	@$(MAKE) -f $(HACK_DIR)/test.mk test
 
-## Ajusta dependências do módulo
-tidy:
-	go mod tidy
+test-v: ## Run tests in verbose mode
+	@$(MAKE) -f $(HACK_DIR)/test.mk test-v
 
-## Target para CI: formata, analisa e testa
-ci: fmt vet test
+test-race: ## Run tests with race detector
+	@$(MAKE) -f $(HACK_DIR)/test.mk test-race
 
-## Setup: instala lefthook e configura git hooks
-# Use ASDF=true para instalar via asdf ao invés de go install
-ASDF ?= false
+cover: ## Generate coverage report (func summary)
+	@$(MAKE) -f $(HACK_DIR)/test.mk cover
 
-setup:
-ifeq ($(ASDF),true)
-	@asdf install
-	@asdf exec lefthook install
-else
-	@go install github.com/evilmartians/lefthook@latest
-	@lefthook install
-endif
-	@echo "Git hooks configured"
+cover-html: ## Generate coverage report (HTML)
+	@$(MAKE) -f $(HACK_DIR)/test.mk cover-html
 
-# Run the example in ./examples/logger (default: DEBUG level)
-# You can override the level by calling e.g. `make run-example LOG_LEVEL=info`
-run-example:
-	cd examples/logger && LOG_LEVEL=$(LOG_LEVEL) go run .
+##@ Security
 
+security: ## Run all security checks (gosec + gitleaks + govulncheck)
+	@$(MAKE) -f $(HACK_DIR)/security.mk run
 
-# security
-.PHONY: security
-security: gosec gitleaks govulncheck
-	@echo "Security checks completed"
+security-%: ## Run a specific security check (e.g. make security-gosec)
+	@$(MAKE) -f $(HACK_DIR)/security.mk $(patsubst security-%,%,$@)
 
-.PHONY: gosec
-gosec:
-	@echo "Running gosec..."
-	@mkdir -p reports
-	@go run github.com/securego/gosec/v2/cmd/gosec@latest -fmt=json -out=reports/gosec-report.json -exclude-dirs=examples ./... 2>&1 || (echo "Security issues were detected!") 
+##@ Setup
 
-.PHONY: gitleaks
-gitleaks:
-	@echo "Running gitleaks..."
-	@docker run -v ${PWD}:/path -v ${PWD}/reports:/reports zricethezav/gitleaks:latest detect \
-		--source="/path" \
-		--report-path="/reports/gitleaks-report.json" \
-		-v || (echo "Secrets were detected!")
-	
-.PHONY: govulncheck
-govulncheck:
-	@echo "Running govulncheck..."
-	@mkdir -p reports
-	@go run golang.org/x/vuln/cmd/govulncheck@latest ./... > reports/govulncheck-report.txt 2>&1 || (echo "Vulnerabilities were detected!")
+setup: ## Install lefthook and configure git hooks
+	@$(MAKE) -f $(HACK_DIR)/setup.mk run
+
+setup-%: ## Run a specific setup step (e.g. make setup-install-lefthook)
+	@$(MAKE) -f $(HACK_DIR)/setup.mk $(patsubst setup-%,%,$@)
+
+##@ Examples
+
+example-run: ## Run an example: make example-run example=<name>
+	@$(MAKE) -f $(HACK_DIR)/examples.mk run example=$(example)

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Logging: API rápida
 
 Kubernetes status: API rápida
 
-- Escrita de conditions (operator/controller):
+- Escrita de conditions:
   - `status.MarkReady(&conditions, gen, status.Reasons.Reconciled, "ready")`
   - `status.MarkReconciling(&conditions, gen, status.Reasons.Reconciling, "installing...")`
-  - `status.MarkWaiting(&conditions, gen, "PendingApproval", "awaiting approval")` — domain reason
+  - `status.MarkWaiting(&conditions, gen, status.Reasons.PreconditionNotMet, "awaiting dependency")`
   - `status.MarkStalled(&conditions, gen, status.Reasons.DependencyNotFound, "CRD not found")`
   - `status.MarkTerminating(&conditions, gen, "terminating")`
-- Leitura/normalização (qualquer consumidor):
+- Leitura/normalização:
   - `status.SummaryFromObject(obj)` — computa `Summary{KStatus, State, Severity, Reason, Message}` on-the-fly.
   - `status.SummaryFromUnstructured(u)` — variante para dynamic client / Unstructured.
   - `status.SummaryFromObject(obj, status.WithSummaryMapping(domainMapping))` — injeta mapeamento de domínio.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Resumo
   concretas (por exemplo `zerolog`).
 - Implementações concretas ficam em `log/internal` (não exportadas).
 - Helpers de trace e propagation em `trace/`.
+- Helpers Kubernetes em `kubernetes/status/` (status padronizado baseado em KStatus) e `utils/kubernetes/transmitter/` (transmitter genérico de CRDs).
 - Exemplos em `examples/` e alvos úteis no `Makefile`.
 
 ## Setup inicial
@@ -30,6 +31,9 @@ Resumo
   - `log/internal/` — implementações concretas (por exemplo `internal/backend/zerolog.go`).
   - `log/middleware/`, `log/util/` — middlewares e helpers relacionados a logging.
 - `trace/` — helpers de propagation (`ContextWithTrace`, `TraceIDFromContext`, `GenerateTraceID`).
+- `kubernetes/status/` — helpers para leitura/escrita de `metav1.Condition`,
+  integração com KStatus oficial e geração de `Summary` padronizado.
+- `utils/kubernetes/transmitter/` — transmitter genérico para publicar status de CRDs.
 - `examples/` — exemplos executáveis (ex.: `examples/logger/main.go`).
 - `Makefile` — targets comuns: `test`, `test-v`, `test-race`, `cover`, `cover-html`, `fmt`, `vet`, `build`, `tidy`, `ci`, `setup`, `run-example`.
 
@@ -43,6 +47,26 @@ Logging: API rápida
 - Helpers de campos: `WithField`, `WithFields` (disponíveis no `LoggerFacade`).
 - Erros: use `LoggerFacade.Error(err)` seguido de `Msg`/`Msgf` para incluir o campo `error` no payload. Ex.: `f.Error(err).Msg("failed")` ou `f.WithFields(...).Error(err).Msgf("failed %s", name)`.
 - Globais/atalhos: `log.SetGlobal(l)`, `log.GetGlobal()` e helpers de nível `log.Debug()/Info()/Warn()/Error(err)` que retornam um `LogEvent` fluente.
+
+Kubernetes status: API rápida
+
+- Escrita de conditions (operator/controller):
+  - `status.MarkReady(&conditions, gen, status.Reasons.Reconciled, "ready")`
+  - `status.MarkReconciling(&conditions, gen, status.Reasons.Reconciling, "installing...")`
+  - `status.MarkWaiting(&conditions, gen, "PendingApproval", "awaiting approval")` — domain reason
+  - `status.MarkStalled(&conditions, gen, status.Reasons.DependencyNotFound, "CRD not found")`
+  - `status.MarkTerminating(&conditions, gen, "terminating")`
+- Leitura/normalização (qualquer consumidor):
+  - `status.SummaryFromObject(obj)` — computa `Summary{KStatus, State, Severity, Reason, Message}` on-the-fly.
+  - `status.SummaryFromUnstructured(u)` — variante para dynamic client / Unstructured.
+  - `status.SummaryFromObject(obj, status.WithSummaryMapping(domainMapping))` — injeta mapeamento de domínio.
+  - `status.NotFoundSummary(reason, message)` — Summary para recurso ausente no cluster.
+  - `status.Compute(obj)` / `status.ComputeFromUnstructured(u)` — KStatus puro sem Summary.
+- Reasons embutidos:
+  - Core: `status.Reasons.Reconciled`, `.Reconciling`, `.Terminating`, `.Unknown`
+  - Common: `status.Reasons.DependencyNotFound`, `.DependencyUnavailable`, `.InvalidConfiguration`, `.PermissionDenied`, `.Conflict`, `.Timeout`, `.PreconditionNotMet`
+  - Domain reasons (ex: `"PendingApproval"`) são definidos no consumer, injetados via `WithSummaryMapping`.
+- Documentação detalhada: `kubernetes/status/README.md`
 
 Adicionando um adapter
 - Para suportar outra biblioteca, adicione um adaptador em `log/adapter/` que construa/retorne um `log.LoggerFacade`.
@@ -77,4 +101,3 @@ Exemplos e documentação adicional
 
 Licença e contato
 - Ver `LICENSE` (se presente) e abra issues/pull requests para contribuições.
-

--- a/examples.mk
+++ b/examples.mk
@@ -1,5 +1,0 @@
-# Examples runner
-.PHONY: run
-
-run:
-	@cd examples/$(example) && go run main.go

--- a/examples/kubernetes-status/main.go
+++ b/examples/kubernetes-status/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	status "github.com/totvs/go-sdk/kubernetes/status"
+)
+
+// writeExample demonstrates operator writing KStatus-compliant conditions.
+func writeExample() {
+	var conditions []metav1.Condition
+	gen := int64(1)
+
+	// resource reconciling
+	status.MarkReconciling(&conditions, gen, status.Reasons.Reconciling, "installing helm chart")
+	log.Printf("  MarkReconciling → conditions: %d", len(conditions))
+
+	// resource ready
+	status.MarkReady(&conditions, gen, status.Reasons.Reconciled, "helm chart installed")
+	log.Printf("  MarkReady → conditions: %d (Reconciling removed)", len(conditions))
+
+	// resource stalled — dependency not found
+	status.MarkStalled(&conditions, gen, status.Reasons.DependencyNotFound, "driver CRD not found")
+	log.Printf("  MarkStalled → conditions: %d (Stalled=True added)", len(conditions))
+
+	// resource waiting — domain reason
+	status.MarkWaiting(&conditions, gen, "PendingApproval", "cluster awaiting approval")
+	log.Printf("  MarkWaiting → conditions: %d (Reconciling+Stalled removed)", len(conditions))
+}
+
+// readDefaultExample demonstrates reading Summary with no custom mapping.
+func readDefaultExample() {
+	conditions := []metav1.Condition{}
+	status.MarkReady(&conditions, 1, status.Reasons.Reconciled, "reconciled")
+
+	obj := buildObject(1, 1, conditions...)
+	summary, err := status.SummaryFromUnstructured(obj)
+	if err != nil {
+		log.Fatalf("SummaryFromUnstructured: %v", err)
+	}
+
+	log.Printf("  KStatus:  %s", summary.KStatus)
+	log.Printf("  State:    %s", summary.State)
+	log.Printf("  Severity: %s", summary.Severity)
+	log.Printf("  Reason:   %s", summary.Reason)
+}
+
+// readWithCustomMappingExample demonstrates injecting domain-specific mapping.
+func readWithCustomMappingExample() {
+	// domain reasons — defined in operator/pkg/platformstatus
+	const reasonPendingApproval status.Reason = "PendingApproval"
+
+	// summary mapping — defined per resource, merged with SDK defaults
+	clusterMapping := status.SummaryMapping{
+		reasonPendingApproval: {State: status.StateWaiting, Severity: status.SeverityWarning},
+	}
+
+	// operator writes
+	conditions := []metav1.Condition{}
+	status.MarkWaiting(&conditions, 1, reasonPendingApproval, "cluster awaiting approval")
+	obj := buildObject(1, 1, conditions...)
+
+	// service-core reads with custom mapping
+	summary, err := status.SummaryFromUnstructured(obj, status.WithSummaryMapping(clusterMapping))
+	if err != nil {
+		log.Fatalf("SummaryFromUnstructured: %v", err)
+	}
+
+	log.Printf("  KStatus:  %s", summary.KStatus)
+	log.Printf("  State:    %s", summary.State)    // waiting (from mapping)
+	log.Printf("  Severity: %s", summary.Severity) // warning (from mapping)
+	log.Printf("  Reason:   %s", summary.Reason)
+}
+
+// commonReasonsExample demonstrates common SDK reasons inferred automatically.
+func commonReasonsExample() {
+	// terminal failures → MarkStalled (KStatus=Failed)
+	stalledCases := []struct {
+		label  string
+		reason status.Reason
+		msg    string
+	}{
+		{"DependencyNotFound", status.Reasons.DependencyNotFound, "driver CRD missing"},
+		{"DependencyUnavailable", status.Reasons.DependencyUnavailable, "database not ready"},
+		{"InvalidConfiguration", status.Reasons.InvalidConfiguration, "invalid helm values"},
+		{"PermissionDenied", status.Reasons.PermissionDenied, "SA missing RBAC"},
+		{"Timeout", status.Reasons.Timeout, "webhook timed out"},
+		{"Conflict", status.Reasons.Conflict, "resource locked"},
+	}
+
+	for _, c := range stalledCases {
+		conditions := []metav1.Condition{}
+		status.MarkStalled(&conditions, 1, c.reason, c.msg)
+		obj := buildObject(1, 1, conditions...)
+
+		summary, err := status.SummaryFromUnstructured(obj)
+		if err != nil {
+			log.Fatalf("SummaryFromUnstructured: %v", err)
+		}
+		log.Printf("  %-25s → state:%-15s severity:%s", c.label, summary.State, summary.Severity)
+	}
+
+	// intentional wait → MarkWaiting (KStatus=InProgress, state=waiting)
+	conditions := []metav1.Condition{}
+	status.MarkWaiting(&conditions, 1, status.Reasons.PreconditionNotMet, "TLS cert not issued")
+	obj := buildObject(1, 1, conditions...)
+
+	summary, err := status.SummaryFromUnstructured(obj)
+	if err != nil {
+		log.Fatalf("SummaryFromUnstructured: %v", err)
+	}
+	log.Printf("  %-25s → state:%-15s severity:%s", "PreconditionNotMet", summary.State, summary.Severity)
+}
+
+// domainConditionExample demonstrates domain conditions alongside KStatus conditions.
+func domainConditionExample() {
+	conditions := []metav1.Condition{}
+	gen := int64(1)
+
+	// KStatus signal
+	status.MarkWaiting(&conditions, gen, "PendingApproval", "awaiting approval")
+
+	// domain condition — business state, does not affect KStatus
+	domainCond := status.NewCondition("ClusterApproved", metav1.ConditionFalse, "PendingApproval", "not yet approved", gen)
+	status.SetCondition(&conditions, domainCond)
+
+	log.Printf("  conditions total: %d", len(conditions))
+	log.Printf("  ClusterApproved: %v", status.IsConditionFalse(conditions, domainCond.Type))
+	log.Printf("  Ready: %v (IsConditionFalse)", status.IsConditionFalse(conditions, status.ConditionTypeReady))
+}
+
+// notFoundExample demonstrates NotFoundSummary for missing resources.
+func notFoundExample() {
+	summary := status.NotFoundSummary(status.Reasons.Unknown, "resource not found in cluster")
+	log.Printf("  KStatus:  %s", summary.KStatus)
+	log.Printf("  State:    %s", summary.State)
+	log.Printf("  Severity: %s", summary.Severity)
+}
+
+// computeExample demonstrates raw KStatus computation without Summary.
+func computeExample() {
+	conditions := []metav1.Condition{}
+	status.MarkStalled(&conditions, 1, status.Reasons.DependencyNotFound, "driver missing")
+	obj := buildObject(1, 1, conditions...)
+
+	ks, err := status.ComputeFromUnstructured(obj)
+	if err != nil {
+		log.Fatalf("Compute: %v", err)
+	}
+	log.Printf("  KStatus: %s", ks) // Failed
+}
+
+func main() {
+	log.Println("=== Kubernetes Status SDK Examples ===")
+	log.Println()
+
+	log.Println("1. Write helpers (operator/controller)")
+	writeExample()
+
+	log.Println("\n2. Read Summary — default mapping")
+	readDefaultExample()
+
+	log.Println("\n3. Read Summary — custom domain mapping")
+	readWithCustomMappingExample()
+
+	log.Println("\n4. Common SDK reasons — automatic inference")
+	commonReasonsExample()
+
+	log.Println("\n5. Domain conditions alongside KStatus")
+	domainConditionExample()
+
+	log.Println("\n6. NotFoundSummary")
+	notFoundExample()
+
+	log.Println("\n7. Raw KStatus computation (no Summary)")
+	computeExample()
+
+	log.Println("\n=== All examples completed ===")
+}
+
+func buildObject(generation, observedGeneration int64, conditions ...metav1.Condition) *unstructured.Unstructured {
+	rawConditions := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		rawConditions = append(rawConditions, map[string]interface{}{
+			"type":               c.Type,
+			"status":             string(c.Status),
+			"reason":             c.Reason,
+			"message":            c.Message,
+			"observedGeneration": c.ObservedGeneration,
+			"lastTransitionTime": c.LastTransitionTime.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "platform.totvs.app/v1",
+		"kind":       "Example",
+		"metadata": map[string]interface{}{
+			"name":       "example",
+			"generation": generation,
+		},
+		"status": map[string]interface{}{
+			"observedGeneration": observedGeneration,
+			"conditions":         rawConditions,
+		},
+	}}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/totvs/go-sdk
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0
@@ -21,6 +21,7 @@ require (
 	k8s.io/client-go v0.35.0
 	k8s.io/component-base v0.35.0
 	k8s.io/klog/v2 v2.130.1
+	sigs.k8s.io/cli-utils v0.37.2
 	sigs.k8s.io/controller-runtime v0.23.1
 )
 
@@ -32,7 +33,7 @@ require (
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -66,7 +67,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/otlptranslator v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,9 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
@@ -134,8 +135,9 @@ github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6u
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
@@ -266,6 +268,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
+sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
 sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
 sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/hack/automations/build.mk
+++ b/hack/automations/build.mk
@@ -1,0 +1,19 @@
+SHELL := /bin/bash
+
+.PHONY: run fmt vet build tidy ci
+
+run: fmt vet build
+
+fmt:
+	gofmt -w .
+
+vet:
+	go vet ./...
+
+build:
+	go build ./...
+
+tidy:
+	go mod tidy
+
+ci: fmt vet test

--- a/hack/automations/examples.mk
+++ b/hack/automations/examples.mk
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+
+EXAMPLES_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(EXAMPLES_MK_DIR)variables.mk
+
+.PHONY: run
+
+# Usage: make example-run example=<name>  (e.g. make example-run example=kubernetes-status)
+run:
+	@if [ -z "$(example)" ]; then \
+		echo "Usage: make example-run example=<name>"; \
+		echo "Available:"; \
+		ls examples/; \
+		exit 1; \
+	fi
+	cd examples/$(example) && LOG_LEVEL=$(LOG_LEVEL) go run main.go

--- a/hack/automations/security.mk
+++ b/hack/automations/security.mk
@@ -1,0 +1,34 @@
+SHELL := /bin/bash
+
+REPORTS_DIR := reports
+
+.PHONY: run gosec gitleaks govulncheck
+
+run: gosec gitleaks govulncheck
+	@echo "Security checks completed"
+
+gosec:
+	@echo "Running gosec..."
+	@mkdir -p $(REPORTS_DIR)
+	@go run github.com/securego/gosec/v2/cmd/gosec@latest \
+		-fmt=json \
+		-out=$(REPORTS_DIR)/gosec-report.json \
+		-exclude-dirs=examples \
+		./... 2>&1 || echo "Warning: Security issues detected"
+
+gitleaks:
+	@echo "Running gitleaks..."
+	@mkdir -p $(REPORTS_DIR)
+	@docker run --rm \
+		-v $(PWD):/path \
+		-v $(PWD)/$(REPORTS_DIR):/reports \
+		zricethezav/gitleaks:latest detect \
+		--source="/path" \
+		--report-path="/reports/gitleaks-report.json" \
+		-v || echo "Warning: Secrets detected"
+
+govulncheck:
+	@echo "Running govulncheck..."
+	@mkdir -p $(REPORTS_DIR)
+	@go run golang.org/x/vuln/cmd/govulncheck@latest ./... \
+		> $(REPORTS_DIR)/govulncheck-report.txt 2>&1 || echo "Warning: Vulnerabilities detected"

--- a/hack/automations/setup.mk
+++ b/hack/automations/setup.mk
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+
+SETUP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SETUP_MK_DIR)variables.mk
+
+.PHONY: run install-lefthook asdf-add-plugins asdf-install
+
+run: install-lefthook
+
+install-lefthook:
+ifeq ($(ASDF),true)
+	@$(MAKE) -f $(SETUP_MK_DIR)setup.mk asdf-add-plugins
+	@$(MAKE) -f $(SETUP_MK_DIR)setup.mk asdf-install
+	@asdf exec lefthook install
+else
+	@go install github.com/evilmartians/lefthook@latest
+	@lefthook install
+endif
+	@echo "Git hooks configured"
+
+asdf-add-plugins:
+	@echo "Adding asdf plugins..."
+	@asdf plugin add golang   https://github.com/asdf-community/asdf-golang.git  2>/dev/null || true
+	@asdf plugin add lefthook https://github.com/jtzero/asdf-lefthook.git        2>/dev/null || true
+
+asdf-install:
+	@echo "Installing asdf tools..."
+	@asdf install

--- a/hack/automations/test.mk
+++ b/hack/automations/test.mk
@@ -1,0 +1,25 @@
+SHELL := /bin/bash
+
+TEST_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(TEST_MK_DIR)variables.mk
+
+.PHONY: run test test-v test-race cover cover-html
+
+run: test
+
+test:
+	go test $(TESTFLAGS) $(TESTPKGS)
+
+test-v:
+	go test -v $(TESTPKGS)
+
+test-race:
+	go test -race -cover -covermode=atomic $(TESTPKGS)
+
+cover:
+	go test -coverprofile=coverage.out $(TESTPKGS)
+	go tool cover -func=coverage.out
+
+cover-html:
+	go test -coverprofile=coverage.out $(TESTPKGS)
+	go tool cover -html=coverage.out

--- a/hack/automations/variables.mk
+++ b/hack/automations/variables.mk
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+TESTPKGS  ?= ./...
+TESTFLAGS ?=
+LOG_LEVEL ?= DEBUG
+ASDF      ?= false

--- a/kubernetes/status/README.md
+++ b/kubernetes/status/README.md
@@ -1,0 +1,350 @@
+# Kubernetes Status (`kubernetes/status`)
+
+Módulo para padronização de status em recursos Kubernetes. Encapsula [KStatus](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus) oficial e expõe helpers de escrita/leitura seguindo as convenções da spec KStatus.
+
+---
+
+## Conceitos
+
+O módulo cobre dois lados da spec KStatus:
+
+**Escrita (operator/controller)** — convenção de como persistir condições no CRD:
+- `Ready`, `Reconciling`, `Stalled` como `type` corretos
+- `observedGeneration` consistente com `metadata.generation`
+- `type` único por condition (upsert, não append)
+
+**Leitura (qualquer consumidor)** — computação on-the-fly a partir dos sinais do objeto:
+
+```text
+observedGeneration != generation  → InProgress  (stale)
+Reconciling=True                  → InProgress
+Stalled=True                      → Failed
+Ready=True                        → Current
+Ready=False/Unknown               → InProgress
+deletionTimestamp presente        → Terminating
+```
+
+> `Summary` é computado na leitura e nunca persistido no CRD.
+
+---
+
+## Setup Rápido
+
+```go
+import status "github.com/totvs/go-sdk/kubernetes/status"
+```
+
+**Operator escreve no final de cada reconcile:**
+
+```go
+// sucesso
+status.MarkReady(&conditions, observedGeneration, status.Reasons.Reconciled, "reconciled")
+
+// em progresso
+status.MarkReconciling(&conditions, observedGeneration, status.Reasons.Reconciling, "installing...")
+
+// bloqueio/erro terminal
+status.MarkStalled(&conditions, observedGeneration, status.Reasons.DependencyNotFound, "CRD not found")
+
+// aguardando input externo
+status.MarkWaiting(&conditions, observedGeneration, "PendingApproval", "awaiting approval")
+
+// deleção
+status.MarkTerminating(&conditions, observedGeneration, "terminating")
+```
+
+**Consumidor lê:**
+
+```go
+summary, err := status.SummaryFromObject(obj)
+// summary.KStatus  → "Failed"
+// summary.State    → "error"
+// summary.Severity → "error"
+// summary.Reason   → "DependencyNotFound"
+// summary.Message  → "CRD not found"
+```
+
+---
+
+## Estrutura
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `types.go` | `KStatus`, `State`, `Severity`, `Reason`, `Reasons`, `Summary` |
+| `conditions.go` | `Mark*`, `NewCondition`, `SetCondition`, `FindCondition`, `IsCondition*` |
+| `summary.go` | `SummaryFromObject`, `SummaryFromUnstructured`, `NotFoundSummary`, `WithSummaryMapping` |
+| `summary_mapping.go` | `SummaryMapping`, `SummaryRule`, `DefaultSummaryMapping`, `Merge`, `Lookup` |
+| `compute.go` | `Compute`, `ComputeFromUnstructured` — KStatus puro sem Summary |
+| `unstructured.go` | helpers internos para ler conditions/generation de `Unstructured` |
+
+---
+
+## Write Helpers
+
+Todos os `Mark*` garantem:
+- `Ready` / `Reconciling` / `Stalled` como `type` correto
+- `observedGeneration` preenchido
+- unicidade de `type` (upsert via `meta.SetStatusCondition`)
+- remoção dos sinais conflitantes (ex: `MarkReady` remove `Reconciling` e `Stalled`)
+
+| Helper | Ready | Reconciling | Stalled | KStatus resultante |
+|---|---|---|---|---|
+| `MarkReady` | True | removido | removido | Current |
+| `MarkReconciling` | False | True | removido | InProgress |
+| `MarkWaiting` | False | removido | removido | InProgress |
+| `MarkStalled` | False | removido | True | Failed |
+| `MarkTerminating` | False | True | removido | Terminating* |
+
+> *`MarkTerminating` seta as conditions. KStatus lê `deletionTimestamp` do objeto real para classificar como `Terminating`.
+
+### Quando usar `MarkStalled`
+
+Use para qualquer bloqueio terminal — quando o controller não pode avançar sem intervenção:
+
+```go
+// dependência ausente ou indisponível
+status.MarkStalled(&conditions, gen, status.Reasons.DependencyNotFound, "secret not found")
+status.MarkStalled(&conditions, gen, status.Reasons.DependencyUnavailable, "database not ready")
+
+// spec inválida
+status.MarkStalled(&conditions, gen, status.Reasons.InvalidConfiguration, "invalid helm values")
+
+// permissão negada
+status.MarkStalled(&conditions, gen, status.Reasons.PermissionDenied, "SA missing cluster-admin")
+
+// timeout de operação externa
+status.MarkStalled(&conditions, gen, status.Reasons.Timeout, "webhook timed out")
+```
+
+### Quando usar `MarkWaiting`
+
+Use para estados de espera legítimos — não são falhas, o controller aguarda intencionalmente:
+
+```go
+// aguardando input humano
+status.MarkWaiting(&conditions, gen, "PendingApproval", "awaiting ops approval")
+
+// aguardando pré-condição (TLS, quota, etc)
+status.MarkWaiting(&conditions, gen, status.Reasons.PreconditionNotMet, "TLS cert not issued")
+```
+
+---
+
+## Reasons
+
+`Reasons` é o vocabulário de reasons embutido no SDK. Acesse via `status.Reasons.<Tab>` para autocomplete.
+
+### Core (usados internamente pelos `Mark*`)
+
+| Reason | Analogia HTTP | Usado em |
+|---|---|---|
+| `Reasons.Reconciled` | ~200 OK | `MarkReady` |
+| `Reasons.Reconciling` | ~102 Processing | `MarkReconciling` |
+| `Reasons.Terminating` | ~102 Processing | `MarkTerminating` |
+| `Reasons.Unknown` | ~520 Unknown | `NotFoundSummary` |
+
+### Common (vocabulário sugerido para controllers)
+
+| Reason | Analogia HTTP | Estado mapeado |
+|---|---|---|
+| `Reasons.InvalidConfiguration` | ~400 Bad Request | `error / error` |
+| `Reasons.DependencyNotFound` | ~404 Not Found | `error / error` |
+| `Reasons.DependencyUnavailable` | ~503 Service Unavailable | `error / warning` |
+| `Reasons.Conflict` | ~409 Conflict | `error / warning` |
+| `Reasons.PreconditionNotMet` | ~428 Precondition Required | `waiting / warning` |
+| `Reasons.PermissionDenied` | ~403 Forbidden | `error / error` |
+| `Reasons.Timeout` | ~408 Request Timeout | `error / warning` |
+
+Reasons de domínio específico (ex: `PendingApproval`, `LicenseExpired`) pertencem ao operator/consumer — não ao SDK.
+
+---
+
+## Summary
+
+`Summary` é o contrato de leitura para API e frontend. Computado on-the-fly, nunca persistido no CRD.
+
+```go
+type Summary struct {
+    KStatus  KStatus  // estado técnico de reconciliação — interop com tooling k8s
+    State    State    // estado de produto — campo principal para UI/API
+    Severity Severity // severidade para renderização visual
+    Reason   Reason   // chave estável de mapeamento (omitempty)
+    Message  string   // mensagem humana/técnica (omitempty)
+}
+```
+
+### KStatus — valores possíveis
+
+| KStatus | Quando |
+|---|---|
+| `Current` | `Ready=True` |
+| `InProgress` | `Reconciling=True` ou `observedGeneration` desatualizado |
+| `Failed` | `Stalled=True` |
+| `Terminating` | `deletionTimestamp` presente |
+| `NotFound` | recurso ausente no cluster |
+| `Unknown` | não determinável |
+
+### State — valores possíveis
+
+`ready` · `progressing` · `waiting` · `warning` · `error` · `terminating` · `notFound` · `unknown`
+
+### Severity — valores possíveis
+
+`success` · `info` · `warning` · `error`
+
+---
+
+## SummaryMapping
+
+`SummaryMapping` define como cada `Reason` é mapeado para `State` + `Severity`.
+
+```go
+type SummaryMapping map[Reason]SummaryRule
+
+type SummaryRule struct {
+    State    State
+    Severity Severity
+}
+```
+
+`DefaultSummaryMapping()` cobre os 4 core reasons + 7 common reasons. Se a `Reason` não estiver no mapeamento, o SDK usa os defaults por KStatus:
+
+```text
+Current     → state:ready,       severity:success
+InProgress  → state:progressing, severity:info
+Failed      → state:error,       severity:error
+Terminating → state:terminating, severity:warning
+NotFound    → state:notFound,    severity:warning
+Unknown     → state:unknown,     severity:warning
+```
+
+### Customizando com reasons de domínio
+
+```go
+// definido no operator/pkg/platformstatus (ou equivalente)
+const ReasonPendingApproval status.Reason = "PendingApproval"
+
+domainMapping := status.SummaryMapping{
+    ReasonPendingApproval: {State: status.StateWaiting, Severity: status.SeverityWarning},
+}
+
+// WithSummaryMapping faz merge sobre DefaultSummaryMapping — base técnica intacta
+summary, err := status.SummaryFromObject(obj, status.WithSummaryMapping(domainMapping))
+```
+
+---
+
+## Conditions de Domínio
+
+Use `NewCondition` + `SetCondition` para conditions de negócio que **complementam** (não substituem) `Ready`/`Reconciling`/`Stalled`:
+
+```go
+const ConditionResourceApproved = "ResourceApproved"
+
+// operator escreve — KStatus signal + condition de domínio
+status.MarkWaiting(&conditions, gen, "PendingApproval", "awaiting approval")
+
+domainCond := status.NewCondition(
+    ConditionResourceApproved,
+    metav1.ConditionFalse,
+    "PendingApproval",
+    "not yet approved",
+    gen,
+)
+status.SetCondition(&conditions, domainCond)
+
+// consumer lê — sem string literal
+approved := status.IsConditionTrue(conditions, ConditionResourceApproved)
+c := status.FindCondition(conditions, ConditionResourceApproved)
+```
+
+---
+
+## Compute — KStatus puro
+
+Use quando precisar apenas do estado técnico, sem `Summary`:
+
+```go
+// a partir de qualquer client.Object
+ks, err := status.Compute(obj)
+
+// a partir de Unstructured (dynamic client, addon-agent)
+ks, err := status.ComputeFromUnstructured(u)
+
+// ks é um dos: KStatusCurrent, KStatusInProgress, KStatusFailed,
+//              KStatusTerminating, KStatusNotFound, KStatusUnknown
+```
+
+---
+
+## Arquitetura de Responsabilidades
+
+```
+go-sdk/kubernetes/status
+  └── DefaultSummaryMapping()    ← base técnica genérica (core + common)
+  └── Reasons.*                  ← vocabulário genérico
+
+operator/pkg/platformstatus      ← domínio específico do operator
+  ├── conditions.go              ← constantes de ConditionType de domínio
+  └── mappings.go                ← SummaryMappings por recurso
+
+service-core / addon-agent
+  └── SummaryFromObject(obj, WithSummaryMapping(platformstatus.ResourceMapping()))
+```
+
+Mudança em mapeamento ou constante de domínio: **um lugar, propaga para todos os consumers**.
+
+---
+
+## Exemplo Completo
+
+```go
+package main
+
+import (
+    "log"
+
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    status "github.com/totvs/go-sdk/kubernetes/status"
+)
+
+func reconcile(obj *MyResource, conditions *[]metav1.Condition) {
+    gen := obj.Generation
+
+    // dependency not found → stalled
+    if !dependencyExists() {
+        status.MarkStalled(conditions, gen, status.Reasons.DependencyNotFound, "config-secret not found")
+        return
+    }
+
+    // installing
+    status.MarkReconciling(conditions, gen, status.Reasons.Reconciling, "applying helm chart")
+    if err := applyHelmChart(); err != nil {
+        status.MarkStalled(conditions, gen, status.Reasons.InvalidConfiguration, err.Error())
+        return
+    }
+
+    // done
+    status.MarkReady(conditions, gen, status.Reasons.Reconciled, "helm chart ready")
+}
+
+func readStatus(obj *MyResource) {
+    // consumer com mapeamento de domínio
+    domainMapping := status.SummaryMapping{
+        "PendingApproval": {State: status.StateWaiting, Severity: status.SeverityWarning},
+    }
+
+    summary, err := status.SummaryFromObject(obj, status.WithSummaryMapping(domainMapping))
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("state=%s severity=%s reason=%s", summary.State, summary.Severity, summary.Reason)
+}
+```
+
+Exemplo executável completo: [`examples/kubernetes-status/main.go`](../../examples/kubernetes-status/main.go)
+
+```bash
+make example-run example=kubernetes-status
+```

--- a/kubernetes/status/compute.go
+++ b/kubernetes/status/compute.go
@@ -1,0 +1,41 @@
+package status
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Compute returns the KStatus for any controller-runtime client object.
+func Compute(obj client.Object) (KStatus, error) {
+	if obj == nil {
+		return KStatusUnknown, fmt.Errorf("object cannot be nil")
+	}
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return ComputeFromUnstructured(u)
+	}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return KStatusUnknown, fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	if gvk := obj.GetObjectKind().GroupVersionKind(); gvk.Kind != "" {
+		u.SetGroupVersionKind(gvk)
+	}
+	return ComputeFromUnstructured(u)
+}
+
+// ComputeFromUnstructured returns the KStatus for an unstructured object.
+func ComputeFromUnstructured(u *unstructured.Unstructured) (KStatus, error) {
+	if u == nil {
+		return KStatusUnknown, fmt.Errorf("object cannot be nil")
+	}
+	result, err := kstatus.Compute(u)
+	if err != nil {
+		return KStatusUnknown, fmt.Errorf("failed to compute kstatus: %w", err)
+	}
+	return KStatus(result.Status), nil
+}

--- a/kubernetes/status/conditions.go
+++ b/kubernetes/status/conditions.go
@@ -1,0 +1,95 @@
+package status
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewCondition builds a metav1.Condition using the SDK reason convention.
+func NewCondition(conditionType string, conditionStatus metav1.ConditionStatus, reason Reason, message string, observedGeneration int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               conditionType,
+		Status:             conditionStatus,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+		Reason:             string(reason),
+		Message:            message,
+	}
+}
+
+// SetCondition upserts a condition by type, following Kubernetes metav1.Condition semantics.
+func SetCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
+	if conditions == nil {
+		return
+	}
+	meta.SetStatusCondition(conditions, condition)
+}
+
+// RemoveCondition removes a condition by type.
+func RemoveCondition(conditions *[]metav1.Condition, conditionType string) {
+	if conditions == nil {
+		return
+	}
+	meta.RemoveStatusCondition(conditions, conditionType)
+}
+
+// FindCondition returns a copy of the condition for the given type.
+func FindCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if strings.EqualFold(conditions[i].Type, conditionType) {
+			condition := conditions[i]
+			return &condition
+		}
+	}
+	return nil
+}
+
+// IsConditionTrue reports whether the condition type exists and has status True.
+func IsConditionTrue(conditions []metav1.Condition, conditionType string) bool {
+	condition := FindCondition(conditions, conditionType)
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}
+
+// IsConditionFalse reports whether the condition type exists and has status False.
+func IsConditionFalse(conditions []metav1.Condition, conditionType string) bool {
+	condition := FindCondition(conditions, conditionType)
+	return condition != nil && condition.Status == metav1.ConditionFalse
+}
+
+// MarkReady marks a resource as reconciled and removes abnormal KStatus conditions.
+func MarkReady(conditions *[]metav1.Condition, observedGeneration int64, reason Reason, message string) {
+	SetCondition(conditions, NewCondition(ConditionTypeReady, metav1.ConditionTrue, reason, message, observedGeneration))
+	RemoveCondition(conditions, ConditionTypeReconciling)
+	RemoveCondition(conditions, ConditionTypeStalled)
+}
+
+// MarkReconciling marks a resource as actively reconciling.
+func MarkReconciling(conditions *[]metav1.Condition, observedGeneration int64, reason Reason, message string) {
+	SetCondition(conditions, NewCondition(ConditionTypeReady, metav1.ConditionFalse, reason, message, observedGeneration))
+	SetCondition(conditions, NewCondition(ConditionTypeReconciling, metav1.ConditionTrue, reason, message, observedGeneration))
+	RemoveCondition(conditions, ConditionTypeStalled)
+}
+
+// MarkWaiting marks a resource as not ready because it is waiting for an external input or dependency.
+func MarkWaiting(conditions *[]metav1.Condition, observedGeneration int64, reason Reason, message string) {
+	SetCondition(conditions, NewCondition(ConditionTypeReady, metav1.ConditionFalse, reason, message, observedGeneration))
+	RemoveCondition(conditions, ConditionTypeReconciling)
+	RemoveCondition(conditions, ConditionTypeStalled)
+}
+
+// MarkStalled marks a resource as blocked or failed.
+func MarkStalled(conditions *[]metav1.Condition, observedGeneration int64, reason Reason, message string) {
+	SetCondition(conditions, NewCondition(ConditionTypeReady, metav1.ConditionFalse, reason, message, observedGeneration))
+	SetCondition(conditions, NewCondition(ConditionTypeStalled, metav1.ConditionTrue, reason, message, observedGeneration))
+	RemoveCondition(conditions, ConditionTypeReconciling)
+}
+
+// MarkTerminating marks the resource conditions as terminating. KStatus itself is
+// still derived from metadata.deletionTimestamp when a full object is evaluated.
+func MarkTerminating(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	SetCondition(conditions, NewCondition(ConditionTypeReady, metav1.ConditionFalse, Reasons.Terminating, message, observedGeneration))
+	SetCondition(conditions, NewCondition(ConditionTypeReconciling, metav1.ConditionTrue, Reasons.Terminating, message, observedGeneration))
+	RemoveCondition(conditions, ConditionTypeStalled)
+}

--- a/kubernetes/status/status_test.go
+++ b/kubernetes/status/status_test.go
@@ -1,0 +1,591 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ── Write Helpers ────────────────────────────────────────────────────────────
+
+func TestMarkReady_RemovesAbnormalConditionsAndSetsReady(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkReconciling(&conditions, 1, Reasons.Reconciling, "reconciling")
+	MarkStalled(&conditions, 1, "ArgumentsInvalid", "arguments invalid")
+
+	// Act
+	MarkReady(&conditions, 2, Reasons.Reconciled, "ready")
+
+	// Assert
+	require.Len(t, conditions, 1)
+	require.True(t, IsConditionTrue(conditions, ConditionTypeReady))
+	require.Nil(t, FindCondition(conditions, ConditionTypeReconciling))
+	require.Nil(t, FindCondition(conditions, ConditionTypeStalled))
+
+	ready := FindCondition(conditions, ConditionTypeReady)
+	require.Equal(t, string(Reasons.Reconciled), ready.Reason)
+	require.Equal(t, int64(2), ready.ObservedGeneration)
+}
+
+func TestMarkReconciling_SetsReconcilingTypeAndRemovesStalled(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, "ArgumentsInvalid", "arguments invalid")
+
+	// Act
+	MarkReconciling(&conditions, 2, Reasons.Reconciling, "installing")
+
+	// Assert
+	require.True(t, IsConditionFalse(conditions, ConditionTypeReady))
+	require.True(t, IsConditionTrue(conditions, ConditionTypeReconciling))
+	require.Nil(t, FindCondition(conditions, ConditionTypeStalled))
+
+	reconciling := FindCondition(conditions, ConditionTypeReconciling)
+	require.Equal(t, string(Reasons.Reconciling), reconciling.Reason)
+	require.Equal(t, int64(2), reconciling.ObservedGeneration)
+}
+
+func TestMarkStalled_SetsStalledTypeAndRemovesReconciling(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkReconciling(&conditions, 1, Reasons.Reconciling, "installing")
+
+	// Act
+	MarkStalled(&conditions, 2, "ArgumentsInvalid", "arguments invalid")
+
+	// Assert
+	require.True(t, IsConditionFalse(conditions, ConditionTypeReady))
+	require.True(t, IsConditionTrue(conditions, ConditionTypeStalled))
+	require.Nil(t, FindCondition(conditions, ConditionTypeReconciling))
+
+	stalled := FindCondition(conditions, ConditionTypeStalled)
+	require.Equal(t, "ArgumentsInvalid", stalled.Reason)
+	require.Equal(t, int64(2), stalled.ObservedGeneration)
+}
+
+func TestMarkWaiting_SetsReadyFalseAndRemovesAbnormalConditions(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkReconciling(&conditions, 1, Reasons.Reconciling, "installing")
+
+	// Act
+	MarkWaiting(&conditions, 2, "PendingApproval", "awaiting approval")
+
+	// Assert
+	require.True(t, IsConditionFalse(conditions, ConditionTypeReady))
+	require.Nil(t, FindCondition(conditions, ConditionTypeReconciling))
+	require.Nil(t, FindCondition(conditions, ConditionTypeStalled))
+
+	ready := FindCondition(conditions, ConditionTypeReady)
+	require.Equal(t, "PendingApproval", ready.Reason)
+	require.Equal(t, int64(2), ready.ObservedGeneration)
+}
+
+func TestMarkTerminating_SetsReconcilingAndReadyFalse(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+
+	// Act
+	MarkTerminating(&conditions, 1, "terminating")
+
+	// Assert
+	require.True(t, IsConditionFalse(conditions, ConditionTypeReady))
+	require.True(t, IsConditionTrue(conditions, ConditionTypeReconciling))
+	require.Nil(t, FindCondition(conditions, ConditionTypeStalled))
+}
+
+// ── Domain Conditions ────────────────────────────────────────────────────────
+
+func TestSetCondition_DomainConditionCoexistsWithKStatusConditions(t *testing.T) {
+	// Arrange
+	const conditionApproved = "Approved"
+	conditions := []metav1.Condition{}
+	MarkWaiting(&conditions, 1, "PendingApproval", "awaiting approval")
+
+	// Act
+	SetCondition(&conditions, NewCondition(
+		conditionApproved,
+		metav1.ConditionFalse,
+		"PendingApproval",
+		"waiting for approval",
+		1,
+	))
+
+	// Assert — domain condition exists alongside KStatus conditions
+	require.Len(t, conditions, 2)
+	require.True(t, IsConditionFalse(conditions, conditionApproved))
+	require.True(t, IsConditionFalse(conditions, ConditionTypeReady))
+}
+
+func TestSetCondition_DomainConditionIsReadByType(t *testing.T) {
+	// Arrange
+	const conditionJoined = "Joined"
+	conditions := []metav1.Condition{}
+
+	// Act
+	domainCondition := NewCondition(conditionJoined, metav1.ConditionTrue, Reasons.Reconciled, "cluster joined", 1)
+	SetCondition(&conditions, domainCondition)
+
+	// Assert — read using the condition's own type, no string literal
+	found := FindCondition(conditions, domainCondition.Type)
+	require.NotNil(t, found)
+	require.True(t, IsConditionTrue(conditions, domainCondition.Type))
+}
+
+// ── Summary — Ready States ───────────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_CurrentWhenReadyAndObservedGenerationMatch(t *testing.T) {
+	// Arrange
+	obj := newStatusObject(2, 2,
+		condition(ConditionTypeReady, metav1.ConditionTrue, Reasons.Reconciled, "ready", 2),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusCurrent, summary.KStatus)
+	require.Equal(t, StateReady, summary.State)
+	require.Equal(t, SeveritySuccess, summary.Severity)
+	require.Equal(t, Reasons.Reconciled, summary.Reason)
+}
+
+func TestSummaryFromUnstructured_InProgressWhenReadyButGenerationIsStale(t *testing.T) {
+	// Arrange — Ready=True but generation advanced, controller hasn't caught up
+	obj := newStatusObject(4, 3,
+		condition(ConditionTypeReady, metav1.ConditionTrue, Reasons.Reconciled, "previously ready", 3),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert — stale Ready=True must not be treated as Current
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateProgressing, summary.State)
+	require.Equal(t, SeverityInfo, summary.Severity)
+}
+
+// ── Summary — Progressing States ─────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_InProgressWhenReconcilingTypeIsTrue(t *testing.T) {
+	// Arrange — Reconciling as type (not as reason on Ready)
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, Reasons.Reconciling, "installing", 1),
+		condition(ConditionTypeReconciling, metav1.ConditionTrue, Reasons.Reconciling, "installing", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateProgressing, summary.State)
+	require.Equal(t, SeverityInfo, summary.Severity)
+	require.Equal(t, Reasons.Reconciling, summary.Reason)
+}
+
+func TestSummaryFromUnstructured_InProgressWhenNotDeployedYet(t *testing.T) {
+	// Arrange
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, "NotDeployed", "not deployed", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateProgressing, summary.State)
+	require.Equal(t, SeverityInfo, summary.Severity)
+}
+
+// ── Summary — Waiting States ─────────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_WaitingWhenPendingApproval(t *testing.T) {
+	// Arrange — PendingApproval is a domain reason, injected via custom mapping
+	const reasonPendingApproval Reason = "PendingApproval"
+	mapping := SummaryMapping{
+		reasonPendingApproval: {State: StateWaiting, Severity: SeverityWarning},
+	}
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, reasonPendingApproval, "waiting for approval", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj, WithSummaryMapping(mapping))
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, reasonPendingApproval, summary.Reason)
+}
+
+func TestSummaryFromUnstructured_WaitingWhenCustomReasonRegisteredInMapping(t *testing.T) {
+	// Arrange — domain-specific waiting reason injected via mapping
+	const customReason Reason = "PendingJoin"
+	mapping := SummaryMapping{
+		customReason: {State: StateWaiting, Severity: SeverityWarning},
+	}
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, customReason, "waiting for join", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj, WithSummaryMapping(mapping))
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+}
+
+// ── Summary — Error States ───────────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_FailedWhenStalledTypeIsTrue(t *testing.T) {
+	// Arrange — Stalled=True signals terminal failure to KStatus
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, "ArgumentsInvalid", "arguments invalid", 1),
+		condition(ConditionTypeStalled, metav1.ConditionTrue, "ArgumentsInvalid", "arguments invalid", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusFailed, summary.KStatus)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+	require.Equal(t, Reason("ArgumentsInvalid"), summary.Reason)
+}
+
+func TestSummaryFromUnstructured_ErrorWhenRequirementsUnsatisfied(t *testing.T) {
+	// Arrange
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, "RequirementsUnsatisfied", "requirements not met", 1),
+		condition(ConditionTypeStalled, metav1.ConditionTrue, "RequirementsUnsatisfied", "requirements not met", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusFailed, summary.KStatus)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+}
+
+func TestSummaryFromUnstructured_ErrorWhenArgumentsInvalid(t *testing.T) {
+	// Arrange
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, "ArgumentsInvalid", "invalid arguments", 1),
+		condition(ConditionTypeStalled, metav1.ConditionTrue, "ArgumentsInvalid", "invalid arguments", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+}
+
+// ── Summary — Not Found ──────────────────────────────────────────────────────
+
+func TestNotFoundSummary_ReturnsNotFoundState(t *testing.T) {
+	// Arrange — resource does not exist in cluster
+
+	// Act
+	summary := NotFoundSummary(Reasons.Unknown, "resource was not found")
+
+	// Assert
+	require.Equal(t, KStatusNotFound, summary.KStatus)
+	require.Equal(t, StateNotFound, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, Reasons.Unknown, summary.Reason)
+	require.Equal(t, "resource was not found", summary.Message)
+}
+
+// ── Summary — Custom Mapping ─────────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_CustomMappingOverridesDefaultSeverity(t *testing.T) {
+	// Arrange — domain wants OwnerApprovalRequired as error severity
+	const customReason Reason = "OwnerApprovalRequired"
+	customMapping := SummaryMapping{
+		customReason: {State: StateWaiting, Severity: SeverityError},
+	}
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, customReason, "owner must approve", 1),
+	)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj, WithSummaryMapping(customMapping))
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityError, summary.Severity) // overridden
+}
+
+func TestSummaryFromUnstructured_CustomMappingDoesNotAffectDefaultReasons(t *testing.T) {
+	// Arrange — custom mapping adds new reason, default reasons unchanged
+	const customReason Reason = "ExternalDependencyMissing"
+	customMapping := SummaryMapping{
+		customReason: {State: StateError, Severity: SeverityError},
+	}
+	const reasonPendingApproval Reason = "PendingApproval"
+	defaultMapping := SummaryMapping{
+		reasonPendingApproval: {State: StateWaiting, Severity: SeverityWarning},
+	}
+	obj := newStatusObject(1, 1,
+		condition(ConditionTypeReady, metav1.ConditionFalse, reasonPendingApproval, "waiting", 1),
+	)
+
+	// Act — custom mapping adds new reason; PendingApproval mapping untouched
+	summary, err := SummaryFromUnstructured(obj, WithSummaryMapping(customMapping.Merge(defaultMapping)))
+
+	// Assert — PendingApproval behavior intact
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+}
+
+// ── Cross-Consumer Consistency ───────────────────────────────────────────────
+
+func TestSummaryFromUnstructured_SameMappingProducesSameResultAcrossConsumers(t *testing.T) {
+	// Arrange — shared mapping defined in platform-types, used by two independent consumers
+	const customReason Reason = "ClusterUnreachable"
+	sharedMapping := SummaryMapping{
+		customReason: {State: StateError, Severity: SeverityError},
+	}
+
+	// consumer A (operator) writes conditions and reads summary
+	conditionsA := []metav1.Condition{}
+	MarkStalled(&conditionsA, 1, customReason, "cluster unreachable")
+
+	obj := newStatusObject(1, 1, conditionsA...)
+	summaryFromOperator, err := SummaryFromUnstructured(obj, WithSummaryMapping(sharedMapping))
+	require.NoError(t, err)
+
+	// consumer B (service-core) — separate process, same object, same mapping
+	summaryFromCore, err := SummaryFromUnstructured(obj, WithSummaryMapping(sharedMapping))
+	require.NoError(t, err)
+
+	// Assert — both consumers produce identical summary
+	require.Equal(t, summaryFromOperator.KStatus, summaryFromCore.KStatus)
+	require.Equal(t, summaryFromOperator.State, summaryFromCore.State)
+	require.Equal(t, summaryFromOperator.Severity, summaryFromCore.Severity)
+	require.Equal(t, summaryFromOperator.Reason, summaryFromCore.Reason)
+
+	// and both have the expected values
+	require.Equal(t, KStatusFailed, summaryFromCore.KStatus)
+	require.Equal(t, StateError, summaryFromCore.State)
+	require.Equal(t, SeverityError, summaryFromCore.Severity)
+	require.Equal(t, customReason, summaryFromCore.Reason)
+}
+
+// ── SummaryMapping Merge ─────────────────────────────────────────────────────
+
+func TestSummaryMappingMerge_OverrideReplacesExistingEntry(t *testing.T) {
+	// Arrange — override changes Reconciled severity from success to warning
+	override := SummaryMapping{
+		Reasons.Reconciled: {State: StateReady, Severity: SeverityWarning},
+	}
+
+	// Act
+	merged := DefaultSummaryMapping().Merge(override)
+
+	// Assert — overridden entry has new values
+	entry := merged[Reasons.Reconciled]
+	require.Equal(t, SeverityWarning, entry.Severity)
+}
+
+func TestSummaryMappingMerge_DefaultEntriesUnaffectedByOverride(t *testing.T) {
+	// Arrange — override touches only Reconciled
+	override := SummaryMapping{
+		Reasons.Reconciled: {State: StateReady, Severity: SeverityWarning},
+	}
+
+	// Act
+	merged := DefaultSummaryMapping().Merge(override)
+
+	// Assert — other default entries remain intact
+	require.Equal(t, SeverityInfo, merged[Reasons.Reconciling].Severity)
+	require.Equal(t, StateTerminating, merged[Reasons.Terminating].State)
+	require.Equal(t, StateUnknown, merged[Reasons.Unknown].State)
+}
+
+func TestSummaryMappingMerge_NewEntryAddedWithoutAffectingDefaults(t *testing.T) {
+	// Arrange — override adds brand new reason not in default mapping
+	const customReason Reason = "ExternalServiceDown"
+	override := SummaryMapping{
+		customReason: {State: StateError, Severity: SeverityError},
+	}
+
+	// Act
+	merged := DefaultSummaryMapping().Merge(override)
+
+	// Assert — new entry present
+	entry, ok := merged[customReason]
+	require.True(t, ok)
+	require.Equal(t, StateError, entry.State)
+
+	// Assert — default entries intact
+	require.Equal(t, SeveritySuccess, merged[Reasons.Reconciled].Severity)
+	require.Equal(t, SeverityInfo, merged[Reasons.Reconciling].Severity)
+}
+
+func TestSummaryMappingMerge_DoesNotMutateOriginalMapping(t *testing.T) {
+	// Arrange
+	base := DefaultSummaryMapping()
+	override := SummaryMapping{
+		Reasons.Reconciled: {State: StateReady, Severity: SeverityWarning},
+	}
+
+	// Act
+	_ = base.Merge(override)
+
+	// Assert — base mapping unchanged
+	require.Equal(t, StateReady, base[Reasons.Reconciled].State)
+	require.Equal(t, SeveritySuccess, base[Reasons.Reconciled].Severity)
+}
+
+// ── Multi-Actor Integration ───────────────────────────────────────────────────
+
+func TestMultiActor_OperatorWritesServiceCoreReads(t *testing.T) {
+
+	// ── operator/pkg/platformstatus ───────────────────────────────────────────
+
+	type clusterConditionType string
+	const (
+		conditionClusterApproved clusterConditionType = "ClusterApproved"
+		conditionClusterJoined   clusterConditionType = "ClusterJoined"
+	)
+
+	// domain reasons — defined in operator, imported by consumers
+	var clusterReasons = struct {
+		PendingApproval Reason
+		UserApproved    Reason
+		PendingJoin     Reason
+	}{
+		PendingApproval: "PendingApproval",
+		UserApproved:    "UserApproved",
+		PendingJoin:     "PendingJoin",
+	}
+
+	// summary mapping — defined per resource, merged with SDK defaults
+	clusterMapping := SummaryMapping{
+		clusterReasons.PendingApproval: {State: StateWaiting, Severity: SeverityWarning},
+		clusterReasons.PendingJoin:     {State: StateWaiting, Severity: SeverityWarning},
+		clusterReasons.UserApproved:    {State: StateReady, Severity: SeveritySuccess},
+	}
+
+	// ── operator: controller ──────────────────────────────────────────────────
+
+	var crdConditions []metav1.Condition
+	observedGeneration := int64(2)
+
+	MarkWaiting(&crdConditions, observedGeneration, clusterReasons.PendingApproval, "cluster awaiting approval")
+
+	SetCondition(&crdConditions, NewCondition(
+		string(conditionClusterApproved), metav1.ConditionFalse,
+		clusterReasons.PendingApproval, "cluster awaiting approval", observedGeneration,
+	))
+	SetCondition(&crdConditions, NewCondition(
+		string(conditionClusterJoined), metav1.ConditionTrue,
+		clusterReasons.UserApproved, "cluster joined successfully", observedGeneration,
+	))
+
+	crdObject := newStatusObject(observedGeneration, observedGeneration, crdConditions...)
+
+	// ── service-core: use case ────────────────────────────────────────────────
+
+	getClusterStatus := func(obj *unstructured.Unstructured) (Summary, bool, bool, error) {
+		summary, err := SummaryFromUnstructured(obj, WithSummaryMapping(clusterMapping))
+		if err != nil {
+			return Summary{}, false, false, err
+		}
+
+		conditions, err := ConditionsFromUnstructured(obj)
+		if err != nil {
+			return Summary{}, false, false, err
+		}
+
+		isApproved := IsConditionTrue(conditions, string(conditionClusterApproved))
+		isJoined := IsConditionTrue(conditions, string(conditionClusterJoined))
+
+		return summary, isApproved, isJoined, nil
+	}
+
+	summary, isApproved, isJoined, err := getClusterStatus(crdObject)
+
+	// ── frontend: consumes service-core response ──────────────────────────────
+	// GET /clusters/:id → { status: { summary, isApproved, isJoined } }
+	// summary.State    → badge color
+	// summary.Reason   → tooltip / analytics
+	// isJoined         → hide join step
+	// isApproved       → disable dependent actions
+
+	// ── assert ────────────────────────────────────────────────────────────────
+
+	require.NoError(t, err)
+
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, clusterReasons.PendingApproval, summary.Reason)
+
+	require.False(t, isApproved, "ClusterApproved should be False — pending approval")
+	require.True(t, isJoined, "ClusterJoined should be True — already joined")
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+func newStatusObject(generation, observedGeneration int64, conditions ...metav1.Condition) *unstructured.Unstructured {
+	rawConditions := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		rawConditions = append(rawConditions, map[string]interface{}{
+			"type":               c.Type,
+			"status":             string(c.Status),
+			"reason":             c.Reason,
+			"message":            c.Message,
+			"observedGeneration": c.ObservedGeneration,
+			"lastTransitionTime": c.LastTransitionTime.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "platform.totvs.app/v1",
+		"kind":       "Example",
+		"metadata": map[string]interface{}{
+			"name":       "example",
+			"generation": generation,
+		},
+		"status": map[string]interface{}{
+			"observedGeneration": observedGeneration,
+			"conditions":         rawConditions,
+		},
+	}}
+}
+
+func condition(conditionType string, status metav1.ConditionStatus, reason Reason, message string, observedGeneration int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+		Reason:             string(reason),
+		Message:            message,
+	}
+}

--- a/kubernetes/status/summary.go
+++ b/kubernetes/status/summary.go
@@ -1,0 +1,177 @@
+package status
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SummaryOptions customizes summary derivation.
+type SummaryOptions struct {
+	SummaryMapping SummaryMapping
+}
+
+// SummaryOption mutates SummaryOptions.
+type SummaryOption func(*SummaryOptions)
+
+// WithSummaryMapping merges m on top of the current mapping (defaults when no prior option was given).
+// Multiple WithSummaryMapping calls compose left-to-right: each one is merged over the previous result.
+func WithSummaryMapping(m SummaryMapping) SummaryOption {
+	return func(options *SummaryOptions) {
+		options.SummaryMapping = options.SummaryMapping.Merge(m)
+	}
+}
+
+// SummaryFromObject computes the normalized Summary for any controller-runtime client object.
+func SummaryFromObject(obj client.Object, opts ...SummaryOption) (Summary, error) {
+	if obj == nil {
+		return Summary{}, fmt.Errorf("object cannot be nil")
+	}
+
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return SummaryFromUnstructured(u, opts...)
+	}
+
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return Summary{}, fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+
+	u := &unstructured.Unstructured{Object: raw}
+	if gvk := obj.GetObjectKind().GroupVersionKind(); gvk.Kind != "" {
+		u.SetGroupVersionKind(gvk)
+	}
+
+	return SummaryFromUnstructured(u, opts...)
+}
+
+// SummaryFromUnstructured computes the normalized Summary for an unstructured object.
+func SummaryFromUnstructured(u *unstructured.Unstructured, opts ...SummaryOption) (Summary, error) {
+	if u == nil {
+		return Summary{}, fmt.Errorf("object cannot be nil")
+	}
+
+	result, err := kstatus.Compute(u)
+	if err != nil {
+		return Summary{}, fmt.Errorf("failed to compute kstatus: %w", err)
+	}
+
+	conditions, err := ConditionsFromUnstructured(u)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	observedGeneration := ObservedGenerationFromUnstructured(u)
+	generation := u.GetGeneration()
+	stale := generation > 0 && observedGeneration > 0 && generation != observedGeneration
+	reconciling := IsConditionTrue(conditions, ConditionTypeReconciling)
+	stalled := IsConditionTrue(conditions, ConditionTypeStalled)
+
+	representative := pickRepresentativeCondition(conditions, KStatus(result.Status), stalled, reconciling)
+
+	var reason Reason
+	var message string
+	if representative != nil {
+		reason = Reason(representative.Reason)
+		message = representative.Message
+	} else {
+		message = result.Message
+	}
+
+	return buildSummary(KStatus(result.Status), reason, message, stale, opts...), nil
+}
+
+// NotFoundSummary returns a Summary for a resource that was not found in the cluster.
+func NotFoundSummary(reason Reason, message string, opts ...SummaryOption) Summary {
+	return buildSummary(KStatusNotFound, reason, message, false, opts...)
+}
+
+func buildSummary(ks KStatus, reason Reason, message string, stale bool, opts ...SummaryOption) Summary {
+	options := SummaryOptions{SummaryMapping: DefaultSummaryMapping()}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	state, severity := defaultStateAndSeverity(ks)
+
+	rule, hasRule := options.SummaryMapping[reason]
+	if hasRule {
+		if rule.State != "" {
+			state = rule.State
+		}
+		if rule.Severity != "" {
+			severity = rule.Severity
+		}
+	}
+
+	// terminal states override mapping
+	if ks == KStatusTerminating {
+		state = StateTerminating
+		severity = SeverityWarning
+	}
+	if ks == KStatusNotFound {
+		state = StateNotFound
+		severity = SeverityWarning
+	}
+	if stale && ks == KStatusInProgress {
+		state = StateProgressing
+		severity = SeverityInfo
+	}
+
+	return Summary{
+		KStatus:  ks,
+		State:    state,
+		Severity: severity,
+		Reason:   reason,
+		Message:  message,
+	}
+}
+
+func pickRepresentativeCondition(conditions []metav1.Condition, ks KStatus, stalled, reconciling bool) *metav1.Condition {
+	if stalled {
+		return FindCondition(conditions, ConditionTypeStalled)
+	}
+	if ks == KStatusTerminating {
+		if c := FindCondition(conditions, ConditionTypeReady); c != nil {
+			return c
+		}
+	}
+	if reconciling {
+		return FindCondition(conditions, ConditionTypeReconciling)
+	}
+	if c := FindCondition(conditions, ConditionTypeReady); c != nil {
+		return c
+	}
+	for i := range conditions {
+		if conditions[i].Status != metav1.ConditionTrue {
+			c := conditions[i]
+			return &c
+		}
+	}
+	if len(conditions) > 0 {
+		c := conditions[0]
+		return &c
+	}
+	return nil
+}
+
+func defaultStateAndSeverity(ks KStatus) (State, Severity) {
+	switch ks {
+	case KStatusCurrent:
+		return StateReady, SeveritySuccess
+	case KStatusFailed:
+		return StateError, SeverityError
+	case KStatusTerminating:
+		return StateTerminating, SeverityWarning
+	case KStatusNotFound:
+		return StateNotFound, SeverityWarning
+	case KStatusInProgress:
+		return StateProgressing, SeverityInfo
+	default:
+		return StateUnknown, SeverityWarning
+	}
+}

--- a/kubernetes/status/summary_mapping.go
+++ b/kubernetes/status/summary_mapping.go
@@ -1,0 +1,52 @@
+package status
+
+// SummaryRule defines how a Reason maps to Summary presentation fields.
+type SummaryRule struct {
+	State    State
+	Severity Severity
+}
+
+// SummaryMapping maps Reason codes to their Summary presentation rules.
+type SummaryMapping map[Reason]SummaryRule
+
+// DefaultSummaryMapping returns the SDK built-in reason-to-summary mapping.
+// Domain-specific reasons belong in the consumer's own SummaryMapping, merged via WithSummaryMapping.
+func DefaultSummaryMapping() SummaryMapping {
+	return coreSummaryMapping().Merge(commonSummaryMapping())
+}
+
+// coreSummaryMapping covers reasons used internally by the SDK Mark* helpers.
+func coreSummaryMapping() SummaryMapping {
+	return SummaryMapping{
+		Reasons.Reconciled:  {State: StateReady, Severity: SeveritySuccess},
+		Reasons.Reconciling: {State: StateProgressing, Severity: SeverityInfo},
+		Reasons.Terminating: {State: StateTerminating, Severity: SeverityWarning},
+		Reasons.Unknown:     {State: StateUnknown, Severity: SeverityWarning},
+	}
+}
+
+// commonSummaryMapping covers suggested vocabulary reasons — mirrors sdkCommonReasons.
+func commonSummaryMapping() SummaryMapping {
+	return SummaryMapping{
+		Reasons.InvalidConfiguration:  {State: StateError, Severity: SeverityError},
+		Reasons.DependencyNotFound:    {State: StateError, Severity: SeverityError},
+		Reasons.DependencyUnavailable: {State: StateError, Severity: SeverityWarning},
+		Reasons.Conflict:              {State: StateError, Severity: SeverityWarning},
+		Reasons.PreconditionNotMet:    {State: StateWaiting, Severity: SeverityWarning},
+		Reasons.PermissionDenied:      {State: StateError, Severity: SeverityError},
+		Reasons.Timeout:               {State: StateError, Severity: SeverityWarning},
+	}
+}
+
+// Merge returns a new SummaryMapping with override entries applied on top of m.
+// The original mapping is not mutated.
+func (m SummaryMapping) Merge(override SummaryMapping) SummaryMapping {
+	merged := make(SummaryMapping, len(m)+len(override))
+	for reason, rule := range m {
+		merged[reason] = rule
+	}
+	for reason, rule := range override {
+		merged[reason] = rule
+	}
+	return merged
+}

--- a/kubernetes/status/summary_mapping_test.go
+++ b/kubernetes/status/summary_mapping_test.go
@@ -1,0 +1,193 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ── Default Mark* → DefaultSummaryMapping inference ──────────────────────────
+
+func TestDefaultMapping_MarkReadyProducesCurrentAndReady(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkReady(&conditions, 1, Reasons.Reconciled, "reconciled")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusCurrent, summary.KStatus)
+	require.Equal(t, StateReady, summary.State)
+	require.Equal(t, SeveritySuccess, summary.Severity)
+	require.Equal(t, Reasons.Reconciled, summary.Reason)
+}
+
+func TestDefaultMapping_MarkReconcilingProducesInProgressAndProgressing(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkReconciling(&conditions, 1, Reasons.Reconciling, "installing")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateProgressing, summary.State)
+	require.Equal(t, SeverityInfo, summary.Severity)
+	require.Equal(t, Reasons.Reconciling, summary.Reason)
+}
+
+func TestDefaultMapping_MarkStalledProducesFailedAndError(t *testing.T) {
+	// Arrange — reason not in any mapping; KStatus default for Failed applies
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, "SomeDomainReason", "unrecognized failure")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert — no mapping match → KStatusFailed default: state=error, severity=error
+	require.NoError(t, err)
+	require.Equal(t, KStatusFailed, summary.KStatus)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+}
+
+func TestDefaultMapping_MarkWaitingProducesInProgress(t *testing.T) {
+	// Arrange — MarkWaiting with unknown reason — no mapping match, falls back to KStatus default
+	conditions := []metav1.Condition{}
+	MarkWaiting(&conditions, 1, Reasons.Unknown, "waiting")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateUnknown, summary.State) // Unknown reason overrides KStatus default
+	require.Equal(t, SeverityWarning, summary.Severity)
+}
+
+// ── Common Reasons → commonSummaryMapping inference ───────────────────────────
+
+func TestCommonMapping_DependencyNotFoundInferredFromCondition(t *testing.T) {
+	// Arrange — operator marks stalled with DependencyNotFound (e.g. driver CRD missing)
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.DependencyNotFound, "driver CRD not found")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act — no custom mapping — commonSummaryMapping covers DependencyNotFound
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusFailed, summary.KStatus)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+	require.Equal(t, Reasons.DependencyNotFound, summary.Reason)
+}
+
+func TestCommonMapping_DependencyUnavailableInferredFromCondition(t *testing.T) {
+	// Arrange — dependency exists but is not ready
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.DependencyUnavailable, "database not ready")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusFailed, summary.KStatus)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity) // warning, not error — dep exists, just unavailable
+	require.Equal(t, Reasons.DependencyUnavailable, summary.Reason)
+}
+
+func TestCommonMapping_InvalidConfigurationInferredFromCondition(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.InvalidConfiguration, "invalid helm values")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+	require.Equal(t, Reasons.InvalidConfiguration, summary.Reason)
+}
+
+func TestCommonMapping_PreconditionNotMetInferredFromCondition(t *testing.T) {
+	// Arrange — resource waiting for a precondition (e.g. cert not yet issued)
+	conditions := []metav1.Condition{}
+	MarkWaiting(&conditions, 1, Reasons.PreconditionNotMet, "TLS cert not yet issued")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, KStatusInProgress, summary.KStatus)
+	require.Equal(t, StateWaiting, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, Reasons.PreconditionNotMet, summary.Reason)
+}
+
+func TestCommonMapping_PermissionDeniedInferredFromCondition(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.PermissionDenied, "service account missing RBAC")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityError, summary.Severity)
+	require.Equal(t, Reasons.PermissionDenied, summary.Reason)
+}
+
+func TestCommonMapping_TimeoutInferredFromCondition(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.Timeout, "webhook took too long")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, Reasons.Timeout, summary.Reason)
+}
+
+func TestCommonMapping_ConflictInferredFromCondition(t *testing.T) {
+	// Arrange
+	conditions := []metav1.Condition{}
+	MarkStalled(&conditions, 1, Reasons.Conflict, "resource locked by another controller")
+	obj := newStatusObject(1, 1, conditions...)
+
+	// Act
+	summary, err := SummaryFromUnstructured(obj)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, StateError, summary.State)
+	require.Equal(t, SeverityWarning, summary.Severity)
+	require.Equal(t, Reasons.Conflict, summary.Reason)
+}

--- a/kubernetes/status/types.go
+++ b/kubernetes/status/types.go
@@ -1,0 +1,100 @@
+package status
+
+import (
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+type KStatus string
+
+const (
+	KStatusInProgress  KStatus = KStatus(kstatus.InProgressStatus)
+	KStatusFailed      KStatus = KStatus(kstatus.FailedStatus)
+	KStatusCurrent     KStatus = KStatus(kstatus.CurrentStatus)
+	KStatusTerminating KStatus = KStatus(kstatus.TerminatingStatus)
+	KStatusNotFound    KStatus = KStatus(kstatus.NotFoundStatus)
+	KStatusUnknown     KStatus = KStatus(kstatus.UnknownStatus)
+)
+
+type State string
+
+const (
+	StateReady       State = "ready"
+	StateProgressing State = "progressing"
+	StateWaiting     State = "waiting"
+	StateWarning     State = "warning"
+	StateError       State = "error"
+	StateTerminating State = "terminating"
+	StateNotFound    State = "notFound"
+	StateUnknown     State = "unknown"
+)
+
+type Severity string
+
+const (
+	SeveritySuccess Severity = "success"
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+// Reason is a stable machine-readable reason code used as a key in SummaryMapping.
+type Reason string
+
+// sdkCoreReasons are used internally by the SDK Mark* helpers.
+type sdkCoreReasons struct {
+	Reconciled  Reason // ~200 OK
+	Reconciling Reason // ~102 Processing
+	Terminating Reason // ~102 Processing (deletion)
+	Unknown     Reason // ~520 Unknown
+}
+
+// sdkCommonReasons are suggested vocabulary for controllers — not used internally by the SDK.
+type sdkCommonReasons struct {
+	InvalidConfiguration  Reason // ~400 Bad Request
+	DependencyNotFound    Reason // ~404 Not Found
+	DependencyUnavailable Reason // ~503 Service Unavailable
+	Conflict              Reason // ~409 Conflict
+	PreconditionNotMet    Reason // ~428 Precondition Required
+	PermissionDenied      Reason // ~403 Forbidden
+	Timeout               Reason // ~408 Request Timeout
+}
+
+type sdkReasons struct {
+	sdkCoreReasons
+	sdkCommonReasons
+}
+
+// Reasons is the SDK built-in reason vocabulary.
+// Do not modify — treat as read-only. Type Reasons. in your IDE to see all available reasons.
+var Reasons = sdkReasons{
+	sdkCoreReasons: sdkCoreReasons{
+		Reconciled:  "Reconciled",
+		Reconciling: "Reconciling",
+		Terminating: "Terminating",
+		Unknown:     "Unknown",
+	},
+	sdkCommonReasons: sdkCommonReasons{
+		InvalidConfiguration:  "InvalidConfiguration",
+		DependencyNotFound:    "DependencyNotFound",
+		DependencyUnavailable: "DependencyUnavailable",
+		Conflict:              "Conflict",
+		PreconditionNotMet:    "PreconditionNotMet",
+		PermissionDenied:      "PermissionDenied",
+		Timeout:               "Timeout",
+	},
+}
+
+const (
+	ConditionTypeReady       = "Ready"
+	ConditionTypeReconciling = string(kstatus.ConditionReconciling)
+	ConditionTypeStalled     = string(kstatus.ConditionStalled)
+)
+
+// Summary is the normalized status contract for API and UI consumers.
+type Summary struct {
+	KStatus  KStatus  `json:"kstatus"`
+	State    State    `json:"state"`
+	Severity Severity `json:"severity"`
+	Reason   Reason   `json:"reason,omitempty"`
+	Message  string   `json:"message,omitempty"`
+}

--- a/kubernetes/status/unstructured.go
+++ b/kubernetes/status/unstructured.go
@@ -1,0 +1,59 @@
+package status
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ConditionsFromUnstructured extracts status.conditions as metav1.Condition.
+func ConditionsFromUnstructured(u *unstructured.Unstructured) ([]metav1.Condition, error) {
+	if u == nil {
+		return nil, fmt.Errorf("object cannot be nil")
+	}
+
+	rawConditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status.conditions: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+
+	conditions := make([]metav1.Condition, 0, len(rawConditions))
+	for i, rawCondition := range rawConditions {
+		rawConditionMap, ok := rawCondition.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("status.conditions[%d] is not an object", i)
+		}
+
+		var condition metav1.Condition
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawConditionMap, &condition); err != nil {
+			return nil, fmt.Errorf("failed to convert status.conditions[%d]: %w", i, err)
+		}
+		conditions = append(conditions, condition)
+	}
+
+	return conditions, nil
+}
+
+// ObservedGenerationFromUnstructured extracts status.observedGeneration.
+func ObservedGenerationFromUnstructured(u *unstructured.Unstructured) int64 {
+	if u == nil {
+		return 0
+	}
+
+	observedGeneration, found, err := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
+	if err == nil && found {
+		return observedGeneration
+	}
+
+	observedGenerationFloat, found, err := unstructured.NestedFloat64(u.Object, "status", "observedGeneration")
+	if err == nil && found {
+		return int64(observedGenerationFloat)
+	}
+
+	return 0
+}


### PR DESCRIPTION
## Summary

- Add `kubernetes/status` module wrapping KStatus (`sigs.k8s.io/cli-utils/pkg/kstatus`)
- Expose `Mark*` write helpers (Ready, Reconciling, Waiting, Stalled, Terminating) — guarantee correct condition types, observedGeneration, and upsert semantics
- Expose `SummaryFromObject` / `SummaryFromUnstructured` computing `Summary{KStatus, State, Severity, Reason, Message}` on-the-fly
- Expose `Compute` / `ComputeFromUnstructured` for raw KStatus access without Summary
- Add built-in `Reasons` vocabulary: 4 core (aligned to KStatus) + 7 common (HTTP-analogous)
- Add `SummaryMapping` strategy — domain reasons injected via `WithSummaryMapping`, merged over defaults
- Add condition helpers: `NewCondition`, `SetCondition`, `FindCondition`, `IsConditionTrue/False`
- Add `examples/kubernetes-status/main.go` with 7 runnable examples
- Add `kubernetes/status/README.md` with full module documentation
- Update root README with current API